### PR TITLE
hide subject facet from main facet nav

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -73,7 +73,7 @@ class CatalogController < ApplicationController
     config.add_facet_field 'dct_provenance_s', label: 'Institution', limit: 8, partial: "icon_facet"
     config.add_facet_field 'dc_creator_sm', :label => 'Author', :limit => 8
     config.add_facet_field 'dc_publisher_s', :label => 'Publisher', :limit => 8
-    config.add_facet_field 'dc_subject_sm', :label => 'Subject', :limit => 8
+    config.add_facet_field 'dc_subject_sm', :label => 'Subject', :limit => 8, show: false
     config.add_facet_field 'dct_spatial_sm', :label => 'Place', :limit => 8
     config.add_facet_field 'dct_isPartOf_sm', :label => 'Collection', :limit => 8
 


### PR DESCRIPTION
Override facet_field_names method to allow removal of facets from the main facet nav.