### PR TITLE
fix layout type helper

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -21,11 +21,19 @@ module ApplicationHelper
   end
 
   ##
+  # Checks if item is the current layout
+  # @return [Boolean]
+  def bookmarks_layout?
+    layout_type == 'bookmarks'
+  end
+
+  ##
   # Gets current layout for use in rendering partials
-  # @return [String] item, index, or home
+  # @return [String] item, index, home, or bookmarks
   def layout_type
-    return 'item' if params[:controller] == 'search_history'
-    if params[:action] == 'show'
+    if %w(search_history bookmarks).include? params[:controller]
+      'bookmarks'
+    elsif params[:action] == 'show'
       'item'
     elsif params[:action] == 'index'
       has_search_parameters? ? 'index' : 'home'

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -28,7 +28,7 @@ module ApplicationHelper
     if params[:action] == 'show'
       'item'
     elsif params[:action] == 'index'
-      params[:q].present? ? 'index' : 'home'
+      has_search_parameters? ? 'index' : 'home'
     end
   end
 end

--- a/spec/helper/application_helper_spec.rb
+++ b/spec/helper/application_helper_spec.rb
@@ -21,9 +21,13 @@ describe ApplicationHelper, type: :helper do
         .and_return(controller: 'catalog', action: 'show')
       expect(layout_type).to eq 'item'
     end
-    it 'should return item when on search history page' do
+    it 'should return bookmarks when on search history page' do
       allow(self).to receive(:params).and_return(controller: 'search_history')
-      expect(layout_type).to eq 'item'
+      expect(layout_type).to eq 'bookmarks'
+    end
+    it 'should return bookmarks when on bookmarks page' do
+      allow(self).to receive(:params).and_return(controller: 'bookmarks')
+      expect(layout_type).to eq 'bookmarks'
     end
   end
   describe '#home_layout?' do
@@ -48,9 +52,19 @@ describe ApplicationHelper, type: :helper do
         .and_return(controller: 'catalog', action: 'show')
       expect(item_layout?).to be true
     end
-    it 'should return true when on search history page' do
+    it 'should return false when on search history page' do
       allow(self).to receive(:params).and_return(controller: 'search_history')
-      expect(item_layout?).to be true
+      expect(item_layout?).to be false
+    end
+  end
+  describe '#bookmarks_layout?' do
+    it 'should return true when on search_history page' do
+      allow(self).to receive(:params).and_return(controller: 'search_history')
+      expect(bookmarks_layout?).to be true
+    end
+    it 'should return true when on search history page' do
+      allow(self).to receive(:params).and_return(controller: 'bookmarks')
+      expect(bookmarks_layout?).to be true
     end
   end
 end

--- a/spec/helper/application_helper_spec.rb
+++ b/spec/helper/application_helper_spec.rb
@@ -1,17 +1,24 @@
 require 'rails_helper'
 
 describe ApplicationHelper, type: :helper do
+  include Geoblacklight::ViewHelperOverride
+
   describe '#layout_type' do
     it 'should return home when on landing page' do
-      allow(self).to receive(:params).and_return(controller: 'catalog', action: 'index')
+      allow(self).to receive(:params)
+        .and_return(controller: 'catalog', action: 'index')
+      allow(self).to receive(:has_search_parameters?).and_return(false)
       expect(layout_type).to eq 'home'
     end
     it 'should return index when on search results page' do
-      allow(self).to receive(:params).and_return(controller: 'catalog', q: 'roads', action: 'index')
+      allow(self).to receive(:params)
+        .and_return(controller: 'catalog', q: 'roads', action: 'index')
+      allow(self).to receive(:has_search_parameters?).and_return(true)
       expect(layout_type).to eq 'index'
     end
     it 'should return item when on show page' do
-      allow(self).to receive(:params).and_return(controller: 'catalog', action: 'show')
+      allow(self).to receive(:params)
+        .and_return(controller: 'catalog', action: 'show')
       expect(layout_type).to eq 'item'
     end
     it 'should return item when on search history page' do
@@ -21,19 +28,24 @@ describe ApplicationHelper, type: :helper do
   end
   describe '#home_layout?' do
     it 'should return true when on landing page' do
-      allow(self).to receive(:params).and_return(controller: 'catalog', action: 'index')
+      allow(self).to receive(:params)
+        .and_return(controller: 'catalog', action: 'index')
+      allow(self).to receive(:has_search_parameters?).and_return(false)
       expect(home_layout?).to be true
     end
   end
   describe '#index_layout?' do
     it 'should return true when on search results page' do
-      allow(self).to receive(:params).and_return(controller: 'catalog', q: 'roads', action: 'index')
+      allow(self).to receive(:params)
+        .and_return(controller: 'catalog', q: 'roads', action: 'index')
+      allow(self).to receive(:has_search_parameters?).and_return(true)
       expect(index_layout?).to be true
     end
   end
   describe '#item_layout?' do
     it 'should return true when on show page' do
-      allow(self).to receive(:params).and_return(controller: 'catalog', action: 'show')
+      allow(self).to receive(:params)
+        .and_return(controller: 'catalog', action: 'show')
       expect(item_layout?).to be true
     end
     it 'should return true when on search history page' do


### PR DESCRIPTION
Use has_search_parameters in layout type method. @tampakis pointed out that facet params can be applied without a query param present.