### PR TITLE
Hide results map when there is an empty response

### DIFF
--- a/app/assets/stylesheets/shame-geo.scss
+++ b/app/assets/stylesheets/shame-geo.scss
@@ -58,3 +58,8 @@ main {
 .navbar + .navbar {
     margin-top: 0;
 }
+
+.no-results {
+    margin-top: 0;
+    margin-bottom: 3em;
+}

--- a/app/views/catalog/_constraints.html.erb
+++ b/app/views/catalog/_constraints.html.erb
@@ -1,9 +1,11 @@
 <% if query_has_constraints? %>
 
       <div id="appliedParams" class="clearfix constraints-container">
+      <%- if !@response.empty? %>
         <div class="pull-right">
           <%=link_to t('blacklight.search.start_over'), start_over_path, :class => "catalog_startOverLink btn btn-sm btn-primary", :id=>"startOverLink" %>
         </div>
+        <%- end %>
         <span class="constraints-label"><%= t('blacklight.search.filters.title') %></span>
         <%= render_constraints(params) %>
       </div>

--- a/app/views/catalog/_sort_and_per_page.html.erb
+++ b/app/views/catalog/_sort_and_per_page.html.erb
@@ -1,0 +1,6 @@
+<%- if !@response.empty? %>
+<div id="sortAndPerPage" class="clearfix">
+  <%= render :partial => "paginate_compact", :object => @response if show_pagination? %>
+  <%= render_results_collection_tools wrapping_class: "search-widgets pull-right" %>
+</div>
+<%- end %>

--- a/app/views/catalog/_zero_results.html.erb
+++ b/app/views/catalog/_zero_results.html.erb
@@ -1,0 +1,1 @@
+<h2 class="no-results"><%= t 'blacklight.search.zero_results.title' %></h2>

--- a/app/views/catalog/index.html.erb
+++ b/app/views/catalog/index.html.erb
@@ -1,9 +1,11 @@
 <% if has_search_parameters? %>
     <%= render :partial=>'/flash_msg', layout: 'shared/flash_messages' %>
 
-    <div id="map-container" class="col-md-6">
-    <%= content_tag :div, '', id: 'map-results', data: { map: 'index', 'catalog-path'=> catalog_index_path , 'map-bbox' => params[:bbox], basemap: geoblacklight_basemap } %>
-    </div>
+    <%- if !@response.empty? %>
+      <div id="map-container" class="col-md-6">
+      <%= content_tag :div, '', id: 'map-results', data: { map: 'index', 'catalog-path'=> catalog_index_path , 'map-bbox' => params[:bbox], basemap: geoblacklight_basemap } %>
+      </div>
+    <%- end %>
 
   <div id="content" class="col-md-6">
     <%= render 'search_header' %>


### PR DESCRIPTION
Hides map on results page when there is an empty response. Otherwise, it looks ugly.