### PR TITLE
default layout outside of catalog controller

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -21,22 +21,24 @@ module ApplicationHelper
   end
 
   ##
-  # Checks if item is the current layout
+  # Checks if default is the current layout
   # @return [Boolean]
-  def bookmarks_layout?
-    layout_type == 'bookmarks'
+  def default_layout?
+    layout_type == 'default'
   end
 
   ##
   # Gets current layout for use in rendering partials
-  # @return [String] item, index, home, or bookmarks
+  # @return [String] item, index, home, or default
   def layout_type
-    if %w(search_history bookmarks).include? params[:controller]
-      'bookmarks'
-    elsif params[:action] == 'show'
-      'item'
-    elsif params[:action] == 'index'
-      has_search_parameters? ? 'index' : 'home'
+    if params[:controller] == 'catalog'
+      if params[:action] == 'show'
+        'item'
+      elsif params[:action] == 'index'
+        has_search_parameters? ? 'index' : 'home'
+      end
+    else
+      'default'
     end
   end
 end

--- a/spec/helper/application_helper_spec.rb
+++ b/spec/helper/application_helper_spec.rb
@@ -21,13 +21,17 @@ describe ApplicationHelper, type: :helper do
         .and_return(controller: 'catalog', action: 'show')
       expect(layout_type).to eq 'item'
     end
-    it 'returns bookmarks when on search history page' do
+    it 'returns default when on search history page' do
       allow(self).to receive(:params).and_return(controller: 'search_history')
-      expect(layout_type).to eq 'bookmarks'
+      expect(layout_type).to eq 'default'
     end
-    it 'returns bookmarks when on bookmarks page' do
+    it 'returns default when on bookmarks page' do
       allow(self).to receive(:params).and_return(controller: 'bookmarks')
-      expect(layout_type).to eq 'bookmarks'
+      expect(layout_type).to eq 'default'
+    end
+    it 'returns default when on saved searches page' do
+      allow(self).to receive(:params).and_return(controller: 'saved_searches')
+      expect(layout_type).to eq 'default'
     end
   end
   describe '#home_layout?' do
@@ -57,14 +61,18 @@ describe ApplicationHelper, type: :helper do
       expect(item_layout?).to be false
     end
   end
-  describe '#bookmarks_layout?' do
+  describe '#default_layout?' do
     it 'returns true when on search_history page' do
       allow(self).to receive(:params).and_return(controller: 'search_history')
-      expect(bookmarks_layout?).to be true
+      expect(default_layout?).to be true
     end
     it 'returns true when on search history page' do
       allow(self).to receive(:params).and_return(controller: 'bookmarks')
-      expect(bookmarks_layout?).to be true
+      expect(default_layout?).to be true
+    end
+    it 'returns true when on saved searches page' do
+      allow(self).to receive(:params).and_return(controller: 'bookmarks')
+      expect(default_layout?).to be true
     end
   end
 end


### PR DESCRIPTION
All of the views requiring the custom layouts are tied to the catalog controller. All other controllers will fallback to the 'default' layout. Closes #52. 