### PR TITLE
disable dynamic when hidden

### DIFF
--- a/app/assets/javascripts/modules/geosearch.js
+++ b/app/assets/javascripts/modules/geosearch.js
@@ -59,7 +59,8 @@
       }, this);
 
       dynamicSearcher = GeoBlacklight.debounce(function() {
-        if (this.options.dynamic) {
+        var display = $('#map-container')[0].style['display']
+        if (this.options.dynamic && display == 'block') {
           this.options.searcher.apply(this);
         }
       }, this.options.delay);


### PR DESCRIPTION
Only enables dynamic search (map zoom in, browser window resize) when the map is visible.