### PR TITLE
hide more details on show page

### DIFF
--- a/app/views/catalog/_upper_metadata.html.erb
+++ b/app/views/catalog/_upper_metadata.html.erb
@@ -11,9 +11,9 @@
         <dd class="blacklight-<%= solr_fname.parameterize %>"><%= render_document_show_field_value document, field: solr_fname %></dd>
       <% end %>
     <% end %>
-    <% if !@document.references.nil? && !@document.references.url.nil? %>
+<!--     <% if !@document.references.nil? && !@document.references.url.nil? %>
       <dt>More details at</dt>
       <dd itemprop="url"><%= link_to @document.references.url.endpoint, @document.references.url.endpoint %></dd>
-    <% end %>
+    <% end %> -->
   </dl>
 </div>


### PR DESCRIPTION
Hide more details section on item show page until the link has a better place to redirect to. Closes #77 