### PR TITLE
fix item view map width

### DIFF
--- a/app/assets/stylesheets/components/map.scss
+++ b/app/assets/stylesheets/components/map.scss
@@ -89,3 +89,8 @@ $basemap-color: #ccdddd;
     padding-right: 0;
   }
 }
+
+// expand viewer container when there is no table container
+#viewer-container:only-child {
+   width: 100% !important;
+}


### PR DESCRIPTION
Item map views without table container (e.g. public wms) should have 100% width. Closes #61 