### PR TITLE
restore range limit slider

### DIFF
--- a/app/assets/stylesheets/geoblacklight.scss
+++ b/app/assets/stylesheets/geoblacklight.scss
@@ -1,2 +1,3 @@
 @import 'geoblacklight/application';
-@import 'blacklight_range_limit';
+@import 'blacklight_range_limit/blacklight_range_limit';
+@import 'slider';


### PR DESCRIPTION
The range-limit css files weren't being included. Now the slider appears and works as expected. Closes #64. I don't think we need #103 any more.