### PR TITLE
Fix thumbnail reload after map search

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -13,7 +13,7 @@
 //= require jquery
 //= require jquery_ujs
 //= require geocomplete
-//= require jail.min
+//= require aload
 
 // Required by Blacklight
 //= require blacklight/blacklight

--- a/app/assets/javascripts/modules/results.js
+++ b/app/assets/javascripts/modules/results.js
@@ -64,7 +64,11 @@ Blacklight.onLoad(function() {
       } else {
         $('#map').after($doc.find('#map').next());
       }
-      $('img.item-thumbnail').jail({event: 'scroll'});
+
+      // reload thumbnail images
+      aload();
+
+      // reload map toggle
       GeoBlacklight.MapToggle.load();
     });
   }

--- a/app/assets/javascripts/modules/thumbnail.js
+++ b/app/assets/javascripts/modules/thumbnail.js
@@ -1,4 +1,4 @@
-// Lazy load images with jail.js
+// asynchronously load images with aload.js
 $(document).ready(function() {
-  $('img.item-thumbnail').jail();
+  aload();
 });

--- a/app/helpers/thumbnail_helper.rb
+++ b/app/helpers/thumbnail_helper.rb
@@ -9,7 +9,7 @@ module ThumbnailHelper
   def gbl_thumbnail_img(document)
     url = document.thumbnail_url
     if url
-      h = "<img class='item-thumbnail' data-src='#{url}'>"
+      h = "<img class='item-thumbnail' data-aload='#{url}'>"
       h += geoblacklight_icon(document['layer_geom_type_s'])
     else
       h = geoblacklight_icon(document['layer_geom_type_s'])

--- a/spec/helpers/thumbnail_helper_spec.rb
+++ b/spec/helpers/thumbnail_helper_spec.rb
@@ -11,7 +11,7 @@ describe ThumbnailHelper, type: :helper do
       it 'returns a geoblacklight icon span and an image tag' do
         allow(document).to receive('thumbnail_url').and_return('http://www.example.com/image.jpg')
         html = Capybara.string(gbl_thumbnail_img(document))
-        expect(html).to have_xpath("//img[@data-src='http://www.example.com/image.jpg']")
+        expect(html).to have_xpath("//img[@data-aload='http://www.example.com/image.jpg']")
         expect(html).to have_xpath("//span[contains(@class,'geoblacklight-polygon')]")
       end
     end

--- a/vendor/assets/javascripts/aload.js
+++ b/vendor/assets/javascripts/aload.js
@@ -1,0 +1,29 @@
+/**
+ * aload - v1.2.2
+ *
+ * Copyright (c) 2016, @pazguille <guille87paz@gmail.com>
+ * Released under the MIT license.
+ */
+/**
+ * Loads images, scripts, styles, iframes, videos and audios asynchronously.
+ * @param {NodeList} [nodes] - A NodeList of elements. By default, it is the result of `querySelectorAll('[data-aload]')`.
+ * @returns {NodeList}
+ */
+function aload(nodes) {
+  'use strict';
+
+  var attribute = 'data-aload';
+
+  nodes = nodes || window.document.querySelectorAll('[' + attribute + ']');
+
+  if (nodes.length === undefined) {
+    nodes = [nodes];
+  }
+
+  [].forEach.call(nodes, function (node) {
+    node[ node.tagName !== 'LINK' ? 'src' : 'href' ] = node.getAttribute(attribute);
+    node.removeAttribute(attribute);
+  });
+
+  return nodes;
+}


### PR DESCRIPTION
Thumbnails now reload properly after pushSate events like map search. Swapped out jail.js for the tiny aload.js library. Closes #119.