### PR TITLE
re-add range limit plugin

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,6 +63,7 @@ group :development do
 end
 
 gem 'blacklight', '~> 5.18.0'
+gem 'blacklight_range_limit'
 gem 'geoblacklight', github:'geoblacklight/geoblacklight', branch: :master
 gem 'rspec-rails', '~> 3.1.0'
 gem 'jettywrapper'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,6 +67,10 @@ GEM
       nokogiri (~> 1.6)
       rails (>= 3.2.6, < 5)
       rsolr (~> 1.0.11)
+    blacklight_range_limit (5.1.0)
+      blacklight (>= 5.0.0.pre4, < 6)
+      jquery-rails
+      rails (>= 3.0, < 5.0)
     bootstrap-sass (3.3.6)
       autoprefixer-rails (>= 5.2.1)
       sass (>= 3.3.4)
@@ -330,6 +334,7 @@ PLATFORMS
 DEPENDENCIES
   autoprefixer-rails
   blacklight (~> 5.18.0)
+  blacklight_range_limit
   byebug
   capistrano (~> 3.4.0)
   capistrano-bundler

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -20,5 +20,6 @@
 // Required by Blacklight
 //= require blacklight/blacklight
 //= require_tree .
+//= require blacklight_range_limit
 
 //= require modernizr

--- a/app/assets/stylesheets/pulmap.scss
+++ b/app/assets/stylesheets/pulmap.scss
@@ -17,5 +17,8 @@
 @import 'components/pagination';
 @import 'components/toggle';
 
+@import 'blacklight_range_limit/blacklight_range_limit';
+@import 'slider';
+
 @import 'shame-geo';
 @import 'bootstrap-toggle';

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -1,5 +1,4 @@
 # -*- encoding : utf-8 -*-
-require 'blacklight/catalog'
 
 class CatalogController < ApplicationController
   include Blacklight::Catalog
@@ -73,9 +72,11 @@ class CatalogController < ApplicationController
     config.add_facet_field Settings.FIELDS.SUBJECT, label: 'Subject', limit: 8, show: true
     config.add_facet_field Settings.FIELDS.SPATIAL_COVERAGE, label: 'Place', limit: 8
     config.add_facet_field Settings.FIELDS.PART_OF, label: 'Collection', limit: 8
-
-    config.add_facet_field Settings.FIELDS.YEAR, label: 'Year', limit: 10
-
+    config.add_facet_field Settings.FIELDS.YEAR, label: 'Year', limit: 10, range: {
+      assumed_boundaries: [1100, 2016]
+      # :num_segments => 6,
+      # :segments => true
+    }
     config.add_facet_field Settings.FIELDS.RIGHTS, label: 'Access', limit: 8, partial: 'icon_facet', show: true
     config.add_facet_field Settings.FIELDS.GEOM_TYPE, label: 'Data type', limit: 8, partial: 'icon_facet'
     config.add_facet_field Settings.FIELDS.FILE_FORMAT, label: 'Format', limit: 8


### PR DESCRIPTION
Re-add the blacklight range limit plugin. Is no longer included by default in Geoblacklight. Closes #123.