### PR TITLE
Add geomonitor integration

### DIFF
--- a/app/assets/stylesheets/components/icons.scss
+++ b/app/assets/stylesheets/components/icons.scss
@@ -1,0 +1,7 @@
+.geoblacklight-available {
+  @extend .fa, .fa-check;
+}
+
+.geoblacklight-unavailable {
+  @extend .fa, .fa-times;
+}

--- a/app/assets/stylesheets/pulmap.scss
+++ b/app/assets/stylesheets/pulmap.scss
@@ -16,6 +16,7 @@
 @import 'components/facets';
 @import 'components/pagination';
 @import 'components/toggle';
+@import 'components/icons';
 
 @import 'blacklight_range_limit/blacklight_range_limit';
 @import 'slider';

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -77,7 +77,22 @@ class CatalogController < ApplicationController
       # :num_segments => 6,
       # :segments => true
     }
-    config.add_facet_field Settings.FIELDS.RIGHTS, label: 'Access', limit: 8, partial: 'icon_facet', show: true
+
+    config.add_facet_field 'access', label: 'Access', query: {
+      public: {
+        label: 'Public', fq: 'dc_rights_s:Public'
+      },
+      restricted: {
+        label: 'Restricted', fq: 'dc_rights_s:Restricted'
+      },
+      available: {
+        label: 'Available', fq: "(layer_availability_score_f:[#{Settings.GEOMONITOR_TOLERANCE} TO 1])"
+      },
+      unavailable: {
+        label: 'Unavailable', fq: "layer_availability_score_f:[0 TO #{Settings.GEOMONITOR_TOLERANCE}]"
+      }
+    }, partial: 'icon_facet'
+
     config.add_facet_field Settings.FIELDS.GEOM_TYPE, label: 'Data type', limit: 8, partial: 'icon_facet'
     config.add_facet_field Settings.FIELDS.FILE_FORMAT, label: 'Format', limit: 8
 

--- a/app/helpers/pulmap_geoblacklight_helper.rb
+++ b/app/helpers/pulmap_geoblacklight_helper.rb
@@ -1,0 +1,8 @@
+module PulmapGeoblacklightHelper
+  include GeoblacklightHelper
+  def document_available?
+    (@document.public? && @document.available?) || (@document.same_institution? &&
+                                                    user_signed_in? &&
+                                                    @document.available?)
+  end
+end

--- a/app/models/concerns/geomonitor_concern.rb
+++ b/app/models/concerns/geomonitor_concern.rb
@@ -1,0 +1,16 @@
+module GeomonitorConcern
+  extend Geoblacklight::SolrDocument
+
+  def available?
+    score_meets_threshold? && super
+  end
+
+  def score_meets_threshold?
+    score = fetch(:layer_availability_score_f, {})
+    if score.present?
+      score > Settings.GEOMONITOR_TOLERANCE
+    else
+      true
+    end
+  end
+end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -3,6 +3,7 @@ class SolrDocument
   include Blacklight::Solr::Document
   include Geoblacklight::SolrDocument
   include ThumbnailConcern
+  include GeomonitorConcern
 
   # self.unique_key = 'id'
   self.unique_key = 'layer_slug_s'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -29,7 +29,7 @@ FIELDS:
   :TEMPORAL: 'dct_temporal_sm'
   :TITLE: 'dc_title_s'
 
-# Institution deployed at
+GEOMONITOR_TOLERANCE: 0.8
 INSTITUTION: 'Princeton'
 
 # Metadata shown in tool panel

--- a/spec/features/unavailable_layer_spec.rb
+++ b/spec/features/unavailable_layer_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+feature 'Unavailable layer' do
+  scenario 'hides and shows appropriate messages for geomonitored unavailable' do
+    visit catalog_path 'harvard-ntadcd106'
+    expect(page).to_not have_content 'Download Shapefile'
+  end
+  scenario 'catalog index page should have availablility facets' do
+    visit catalog_index_path q: '*'
+    expect(page).to have_css '.facet_select', text: 'Unavailable'
+    expect(page).to have_css '.facet_select', text: 'Available'
+  end
+end

--- a/spec/fixtures/solr_documents/harvard_raster.json
+++ b/spec/fixtures/solr_documents/harvard_raster.json
@@ -43,5 +43,6 @@
   "layer_modified_dt": "2014-05-27T18:09:36Z",
   "solr_geom": "ENVELOPE(30.013108, 30.875309, 60.041712, 59.669749)",
   "solr_year_i": 1834,
-  "solr_issued_dt": "2000-01-01T00:00:00Z"
+  "solr_issued_dt": "2000-01-01T00:00:00Z",
+  "layer_availability_score_f": 0.9
 }

--- a/spec/fixtures/solr_documents/restricted-line.json
+++ b/spec/fixtures/solr_documents/restricted-line.json
@@ -1,42 +1,42 @@
 {
-        "uuid": "http://purl.stanford.edu/cg357zz0321",
-        "dc_identifier_s": "http://purl.stanford.edu/cg357zz0321",
-        "dc_title_s": "10 Meter Countours: Russian River Basin, California",
-        "dc_description_s": "This line shapefile contains contours that were derived from a mosiac of 10 meter digital elevation models for the extent of the Russian River basin, located in Sonoma and Mendocino Counties, California.This layer can be used for watershed analysis and planning in the Russian River region of California.",
-        "dc_rights_s": "Restricted",
-        "dct_provenance_s": "Stanford",
-        "dct_references_s": "{\"http://schema.org/url\":\"http://purl.stanford.edu/cg357zz0321\",\"http://schema.org/downloadUrl\":\"http://stacks.stanford.edu/file/druid:cg357zz0321/data.zip\",\"http://www.loc.gov/mods/v3\":\"http://purl.stanford.edu/cg357zz0321.mods\",\"http://www.isotc211.org/schemas/2005/gmd/\":\"https://raw.githubusercontent.com/OpenGeoMetadata/edu.stanford.purl/master/cg/357/zz/0321/iso19139.xml\",\"http://www.w3.org/1999/xhtml\":\"http://opengeometadata.stanford.edu/metadata/edu.stanford.purl/druid:cg357zz0321/default.html\",\"http://www.opengis.net/def/serviceType/ogc/wfs\":\"http://geowebservices-restricted.stanford.edu/geoserver/wfs\",\"http://www.opengis.net/def/serviceType/ogc/wms\":\"http://geowebservices-restricted.stanford.edu/geoserver/wms\"}",
-        "layer_id_s": "druid:cg357zz0321",
-        "layer_slug_s": "stanford-cg357zz0321",
-        "layer_geom_type_s": "Line",
-        "layer_modified_dt": "2014-12-03T01:20:46Z",
-        "dc_format_s": "Shapefile",
-        "dc_language_s": "English",
-        "dc_type_s": "Dataset",
-        "dc_publisher_s": "Circuit Rider Productions",
-        "dc_creator_sm": [
-          "United States. National Oceanic and Atmospheric Administration",
-          "Circuit Rider Productions"
-        ],
-        "dc_subject_sm": [
-          "Contours (Cartography)",
-          "Elevation",
-          "Inland Waters"
-        ],
-        "dct_issued_s": "2003",
-        "dct_temporal_sm": [
-          "2002"
-        ],
-        "dct_spatial_sm": [
-          "Sonoma County (Calif.)",
-          "Mendocino County (Calif.)"
-        ],
-        "dc_relation_sm": [
-          "http://sws.geonames.org/5397100/about.rdf",
-          "http://sws.geonames.org/5372163/about.rdf"
-        ],
-        "georss_box_s": "38.302994 -123.387366 39.398403 -122.52958",
-        "georss_polygon_s": "38.302994 -123.387366 39.398403 -123.387366 39.398403 -122.52958 38.302994 -122.52958 38.302994 -123.387366",
-        "solr_geom": "ENVELOPE(-123.387366, -122.52958, 39.398403, 38.302994)",
-        "solr_year_i": 2002
-      }
+  "uuid": "http://purl.stanford.edu/cg357zz0321",
+  "dc_identifier_s": "http://purl.stanford.edu/cg357zz0321",
+  "dc_title_s": "10 Meter Countours: Russian River Basin, California",
+  "dc_description_s": "This line shapefile contains contours that were derived from a mosiac of 10 meter digital elevation models for the extent of the Russian River basin, located in Sonoma and Mendocino Counties, California.This layer can be used for watershed analysis and planning in the Russian River region of California.",
+  "dc_rights_s": "Restricted",
+  "dct_provenance_s": "Stanford",
+  "dct_references_s": "{\"http://schema.org/url\":\"http://purl.stanford.edu/cg357zz0321\",\"http://schema.org/downloadUrl\":\"http://stacks.stanford.edu/file/druid:cg357zz0321/data.zip\",\"http://www.loc.gov/mods/v3\":\"http://purl.stanford.edu/cg357zz0321.mods\",\"http://www.isotc211.org/schemas/2005/gmd/\":\"https://raw.githubusercontent.com/OpenGeoMetadata/edu.stanford.purl/master/cg/357/zz/0321/iso19139.xml\",\"http://www.w3.org/1999/xhtml\":\"http://opengeometadata.stanford.edu/metadata/edu.stanford.purl/druid:cg357zz0321/default.html\",\"http://www.opengis.net/def/serviceType/ogc/wfs\":\"http://geowebservices-restricted.stanford.edu/geoserver/wfs\",\"http://www.opengis.net/def/serviceType/ogc/wms\":\"http://geowebservices-restricted.stanford.edu/geoserver/wms\"}",
+  "layer_id_s": "druid:cg357zz0321",
+  "layer_slug_s": "stanford-cg357zz0321",
+  "layer_geom_type_s": "Line",
+  "layer_modified_dt": "2014-12-03T01:20:46Z",
+  "dc_format_s": "Shapefile",
+  "dc_language_s": "English",
+  "dc_type_s": "Dataset",
+  "dc_publisher_s": "Circuit Rider Productions",
+  "dc_creator_sm": [
+    "United States. National Oceanic and Atmospheric Administration",
+    "Circuit Rider Productions"
+  ],
+  "dc_subject_sm": [
+    "Contours (Cartography)",
+    "Elevation",
+    "Inland Waters"
+  ],
+  "dct_issued_s": "2003",
+  "dct_temporal_sm": [
+    "2002"
+  ],
+  "dct_spatial_sm": [
+    "Sonoma County (Calif.)",
+    "Mendocino County (Calif.)"
+  ],
+  "dc_relation_sm": [
+    "http://sws.geonames.org/5397100/about.rdf",
+    "http://sws.geonames.org/5372163/about.rdf"
+  ],
+  "georss_box_s": "38.302994 -123.387366 39.398403 -122.52958",
+  "georss_polygon_s": "38.302994 -123.387366 39.398403 -123.387366 39.398403 -122.52958 38.302994 -122.52958 38.302994 -123.387366",
+  "solr_geom": "ENVELOPE(-123.387366, -122.52958, 39.398403, 38.302994)",
+  "solr_year_i": 2002
+}

--- a/spec/fixtures/solr_documents/unvailable.json
+++ b/spec/fixtures/solr_documents/unvailable.json
@@ -1,0 +1,25 @@
+{
+  "uuid": "urn:hul.harvard.edu:HARVARD.SDE.NTADCD106",
+  "dc_description_s": "The 106th Congressional District Boundaries data set contains geographic information for the political entities of the Congressional districts of the United States and U.S. Territories.",
+  "dc_format_s": "Shapefile",
+  "dc_identifier_s": "urn:hul.harvard.edu:HARVARD.SDE.NTADCD106",
+  "dc_language_s": "English",
+  "dc_publisher_s": "Bureau of Transportation Statistics",
+  "dc_rights_s": "Public",
+  "dc_title_s": "106th Congressional District Boundaries",
+  "dc_type_s": "Dataset",
+  "dct_references_s": "{\"http://www.opengis.net/def/serviceType/ogc/wfs\":\"http://hgl.harvard.edu:8080/geoserver/wfs\",\"http://www.opengis.net/def/serviceType/ogc/wms\":\"http://hgl.harvard.edu:8080/geoserver/wms\",\"http://schema.org/UserDownloads\":\"http://hgl.harvard.edu:8080/HGL/RemoteServiceStarter\",\"http://tilecache.org\":\"http://hgl.harvard.edu/cgi-bin/tilecache/tilecache.cgi\",\"http://www.opengis.net/cat/csw/csdgm\":\"http://opengeometadata.stanford.edu/metadata/org.opengeoportal/sde:SDE.NTADCD106/fgdc.xml\",\"http://www.w3.org/1999/xhtml\":\"http://opengeometadata.stanford.edu/metadata/org.opengeoportal/sde:SDE.NTADCD106/fgdc.html\",\"http://schema.org/url\":\"http://opengeometadata.stanford.edu/metadata/org.opengeoportal/sde:SDE.NTADCD106/fgdc.html\"}",
+  "dct_temporal_sm": [
+    "1999"
+  ],
+  "dct_provenance_s": "Harvard",
+  "georss_box_s": "-14.602623 -179.149436 71.331916 179.759346",
+  "georss_polygon_s": "71.331916 -179.149436 71.331916 179.759346 -14.602623 179.759346 -14.602623 -179.149436 71.331916 -179.149436",
+  "layer_slug_s": "harvard-ntadcd106",
+  "layer_id_s": "sde:SDE.NTADCD106",
+  "layer_geom_type_s": "Polygon",
+  "layer_modified_dt": "2014-12-16T00:47:27Z",
+  "solr_geom": "ENVELOPE(-179.149436, 179.759346, 71.331916, -14.602623)",
+  "solr_year_i": 1999,
+  "layer_availability_score_f": 0.7
+}

--- a/spec/models/concerns/geomonitor_concern_spec.rb
+++ b/spec/models/concerns/geomonitor_concern_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+describe GeomonitorConcern do
+  let(:document) { SolrDocument.new(document_attributes) }
+  describe 'available?' do
+    describe 'for Princeton resources' do
+      let(:document_attributes) do
+        {
+          dct_provenance_s: 'Princeton',
+          dc_rights_s: 'Restricted'
+        }
+      end
+      it 'calls super logic' do
+        expect(document.available?).to be_truthy
+      end
+    end
+    describe 'for resources less than threshold tolerance' do
+      let(:document_attributes) do
+        {
+          dct_provenance_s: 'Harvard',
+          dc_rights_s: 'Restricted',
+          layer_availability_score_f: 0.6
+        }
+      end
+      it 'is not avilable' do
+        expect(document.available?).to be_falsey
+      end
+    end
+  end
+  describe 'score_meets_threshold?' do
+    let(:document_attributes) { {} }
+    it 'no score present' do
+      expect(document.score_meets_threshold?).to be_truthy
+    end
+  end
+end


### PR DESCRIPTION
Adds geomonitor integration. Mostly borrowed (with love) from Earthworks.

<img width="314" alt="screenshot 2016-07-06 09 41 56" src="https://cloud.githubusercontent.com/assets/784196/16620681/5b514734-4361-11e6-927c-0cc453ae6cf1.png">

Thanks to @mejackreed and @drh-stanford.