### PR TITLE
Update thumbnail tasks and create setting for using thumbnail refs

### DIFF
--- a/app/assets/javascripts/modules/flash.js
+++ b/app/assets/javascripts/modules/flash.js
@@ -1,4 +1,3 @@
-// asynchronously load images with aload.js
 $(document).ready(function() {
     // Auto dismiss alert-info
     setTimeout(function() {

--- a/app/assets/stylesheets/components/thumbnail.scss
+++ b/app/assets/stylesheets/components/thumbnail.scss
@@ -46,3 +46,5 @@
     opacity: 0.8;
   }
 }
+
+[data-aload] { background-image: none !important; }

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -90,6 +90,7 @@ LEAFLET:
       <<: *opacity_control
 
 THUMBNAIL:
+  USE_DCT_REFS: false
   SIZE: 200 # Size of thumbnail to request
   BASE_PATH: "thumbnails" # Base path for thumbnail urls
   FILE_BASE_PATH: "./public" # Path to parent of thumbnail images directory

--- a/lib/thumbnail.rb
+++ b/lib/thumbnail.rb
@@ -4,12 +4,16 @@ class Thumbnail
   end
 
   ##
-  # Get the thumbnail url from dctrefs. Ff not in dctrefs, then
-  # get it from a service endpoint (WMS, IIIF, etc...). Return
-  # nil if both of those fail, so the thumbnail is not displayed.
+  # Get the thumbnail url from dctrefs if turned on in settings.
+  # If not in dctrefs, then get it from a service endpoint (WMS, IIIF, etc...).
+  # Return nil if both of those fail, so the thumbnail is not displayed.
   # @return [String, nil] thumbnail url
   def url
-    thumbnail_reference || generated_thumbnail
+    if Settings.THUMBNAIL.USE_DCT_REFS
+      thumbnail_reference || generated_thumbnail
+    else
+      generated_thumbnail
+    end
   end
 
   ##

--- a/lib/thumbnail/persist_thumbnail.rb
+++ b/lib/thumbnail/persist_thumbnail.rb
@@ -20,6 +20,7 @@ class PersistThumbnail
     create_temp_file
     download = initiate_download
     return if download.nil?
+    return unless download.class == Faraday::Request
     save_file(download)
   end
 
@@ -65,6 +66,6 @@ class PersistThumbnail
     end
     File.rename("#{@file_path}.tmp", "#{@file_path}")
   rescue Geoblacklight::Exceptions::WrongDownloadFormat
-    File.rename("#{@file_path}.tmp", "#{@file_path}.error")
+    suppress(Exception) { File.rename("#{@file_path}.tmp", "#{@file_path}.error") }
   end
 end

--- a/spec/lib/thumbnail/persist_thumbnail_spec.rb
+++ b/spec/lib/thumbnail/persist_thumbnail_spec.rb
@@ -6,6 +6,7 @@ describe PersistThumbnail do
   let(:req_options) { double('opts', 'timeout=' => 60, 'open_timeout=' => 60) }
   let(:body) { double('body') }
   let(:persist) { described_class.new(options) }
+  let(:download) { double('file') }
   let(:file_path) { './test/thumbnail.png' }
   let(:thumb_file) { double('thumb_file') }
   let(:url) { 'http://www.example.com/thumbnail' }
@@ -24,10 +25,11 @@ describe PersistThumbnail do
   end
 
   describe '#create_file' do
-    it 'creates temp file, doownloads thumbnail and saves it' do
+    it 'creates temp file, downloads thumbnail and saves it' do
+      allow(download).to receive(:class).and_return(Faraday::Request)
       expect(persist).to receive(:create_temp_file)
-      expect(persist).to receive(:initiate_download).and_return('file')
-      expect(persist).to receive(:save_file).with('file')
+      expect(persist).to receive(:initiate_download).and_return(download)
+      expect(persist).to receive(:save_file).with(download)
       persist.create_file
     end
 

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -5,6 +5,9 @@ describe SolrDocument do
   let(:document_attributes) { { dct_references_s: refs } }
   let(:refs) { '{"http://schema.org/thumbnailUrl":"http://example.com/thumb.jpg"}' }
 
+  before do
+    allow(Settings.THUMBNAIL).to receive(:USE_DCT_REFS).and_return(true)
+  end
   describe '#thumbnail_url' do
     it 'returns a url for the thumbnail' do
       expect(document.thumbnail_url).to eq('http://example.com/thumb.jpg')


### PR DESCRIPTION
Adds config settings to use thumbnail refs instead of generated thumbnails. Improves thumbnail caching rake tasks. Closes #152.