### PR TITLE
map search on zoom or drag, hide map toggle on small screens

### DIFF
--- a/app/assets/javascripts/geoblacklight.js
+++ b/app/assets/javascripts/geoblacklight.js
@@ -10,6 +10,7 @@
 //= require geoblacklight/downloaders
 //= require modules/mapPosition
 //= require modules/locationsearch
+//= require modules/facets-toggle
 //= require modules/home
 //= require modules/map
 //= require modules/results

--- a/app/assets/javascripts/modules/facets-toggle.js
+++ b/app/assets/javascripts/modules/facets-toggle.js
@@ -1,0 +1,6 @@
+// asynchronously load images with aload.js
+$(document).ready(function() {
+  $('.facets-toggle').click(function() {
+    $('.facet-view').show();
+  });
+});

--- a/app/assets/stylesheets/components/toggle.scss
+++ b/app/assets/stylesheets/components/toggle.scss
@@ -10,3 +10,10 @@
 .toggle {
   border-color: $gray;
 }
+
+#appliedParams > .toggle {
+
+  @media (max-width: $bp-small) {
+    display: none;
+  }
+}


### PR DESCRIPTION
Takes advantage of [dragend event](http://leafletjs.com/reference.html#map-events) to ensure map search updates only happen when the user moves the map.

Hides the map toggle button on smaller screen width. Clicking the facets toggle button on small screen width ensures the facets display even when map view is on (and facets are hidden).