### PR TITLE
Correct issue with loading index page map

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,7 +63,7 @@ group :development do
 end
 
 gem 'blacklight_range_limit'
-gem 'geoblacklight', '1.0.0'
+gem 'geoblacklight', '1.0.1'
 gem 'bourbon'
 gem 'neat'
 gem 'rspec-rails', '~> 3.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,7 +127,7 @@ GEM
       multipart-post (>= 1.2, < 3)
     font-awesome-rails (4.1.0.0)
       railties (>= 3.2, < 5.0)
-    geoblacklight (1.0.0)
+    geoblacklight (1.0.1)
       blacklight (~> 6.3)
       coderay
       faraday
@@ -343,7 +343,7 @@ DEPENDENCIES
   devise
   devise-guests (~> 0.3.3)
   factory_girl_rails
-  geoblacklight (= 1.0.0)
+  geoblacklight (= 1.0.1)
   geocomplete_rails
   jbuilder (~> 2.0)
   jquery-rails

--- a/app/assets/javascripts/modules/results.js
+++ b/app/assets/javascripts/modules/results.js
@@ -1,4 +1,4 @@
-Blacklight.onLoad(function() {
+$(document).ready(function() {
   var historySupported = !!(window.history && window.history.pushState);
   
   if (historySupported) {


### PR DESCRIPTION
This PR corrects an issue with loading the index page geosearch map. 

Problem:
1. Run a search from the home page
1. Put the index page in the facet view using map toggle button.This preference is saved in the cookies.
1. Click the 'Start Over' button.
1. Run another search from the homepage.
1. Toggle the map on the index page.
1. The map is centered on an odd location.

<img width="1202" alt="screenshot 2016-07-29 16 15 28" src="https://cloud.githubusercontent.com/assets/784196/17263874/16a70560-55a9-11e6-8f34-e6773117d047.png">
