### PR TITLE
Use https repo url for cap deployment

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -2,7 +2,7 @@
 lock '>=3.4'
 
 set :application, 'pulmap'
-set :repo_url, 'git@github.com:pulibrary/pulmap.git'
+set :repo_url, 'https://github.com/pulibrary/pulmap.git'
 set :branch, 'master'
 
 # Default branch is :master


### PR DESCRIPTION
Use the https repo url for capistrano deployment. Attempt to fix automated deployment issue.