### PR TITLE
activate homepage location search on map move event

### DIFF
--- a/app/assets/javascripts/modules/locationsearch.js
+++ b/app/assets/javascripts/modules/locationsearch.js
@@ -25,6 +25,7 @@ Blacklight.onLoad(function() {
 
     function toggleMapSearch() {
       searchState = !searchState;
+      $('.leaflet-container').toggleClass('active');
       if (searchState) {
         addBboxField();
       } else {
@@ -34,18 +35,19 @@ Blacklight.onLoad(function() {
 
     $('.btn-toggle').click(function() {
       toggleMapSearch();
-      $('.leaflet-container').toggleClass('active');
     });
 
     // hide zoom control on load
     $('.leaflet-control-zoom').toggle();
 
-    // update bbox field on map move
+    // turn on map search and update bbox field on map move
     GeoBlacklight.Home.map.on('moveend', function(e) {
-      if (searchState) {
-        updateBboxField();
-        resetPlaceInput();
+      if (!searchState) {
+        toggleMapSearch();
+        $('#map-toggle').prop('checked', true).change()
       }
+      updateBboxField();
+      resetPlaceInput();
     });
   });
 });

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -4,5 +4,7 @@ en:
     search:
       form:
         submit: 'Search'
+        search_field:
+          label: 'Search...'
     header_links:
       account_page: 'Your Account'


### PR DESCRIPTION
When the user moves the map or searches for a location on the homepage, map search functionality is activated.

Closes #186 