### PR TITLE
Add spatial parameters to search builder

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -29,6 +29,14 @@ Metrics/LineLength:
     - 'app/controllers/catalog_controller.rb'
     - 'spec/lib/thumbnail_spec.rb'
 
+Metrics/MethodLength:
+  Exclude:
+    - 'app/models/search_builder.rb'
+
+RSpec/NamedSubject:
+  Exclude:
+    - 'spec/models/search_builder_spec.rb'
+
 # TODO: Add top-level class and module documentation.
 Style/Documentation:
   Enabled: false

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -4,4 +4,19 @@ class SearchBuilder < Blacklight::SearchBuilder
   include BlacklightRangeLimit::RangeLimitBuilder
 
   include Geoblacklight::SpatialSearchBehavior
+
+  # spatial search improvements from earthworks
+  def add_spatial_params(solr_params)
+    if blacklight_params[:bbox]
+      solr_params[:bq] ||= []
+      solr_params[:bq] =
+        ["#{Settings.GEOMETRY_FIELD}:\"IsWithin(#{envelope_bounds})\"^300"]
+      solr_params[:fq] ||= []
+      solr_params[:fq] <<
+        "#{Settings.GEOMETRY_FIELD}:\"Intersects(#{envelope_bounds})\""
+    end
+    solr_params
+  rescue Geoblacklight::Exceptions::WrongBoundingBoxFormat
+    solr_params
+  end
 end

--- a/spec/models/search_builder_spec.rb
+++ b/spec/models/search_builder_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+describe SearchBuilder do
+  let(:user_params) { Hash.new }
+  let(:solr_params) { Hash.new }
+  let(:blacklight_config) { CatalogController.blacklight_config.deep_copy }
+  let(:context) { CatalogController.new }
+
+  let(:search_builder) { described_class.new(context) }
+
+  subject { search_builder.with(user_params) }
+
+  describe '#add_spatial_params' do
+    it 'returns the solr_params when no bbox is given' do
+      expect(subject.add_spatial_params(solr_params)).to eq solr_params
+    end
+
+    context 'when a bbox is given' do
+      params = { bbox: '-180 -80 120 80' }
+
+      it 'returns a spatial search with ' do
+        subject.with(params)
+        expect(subject.add_spatial_params(solr_params)[:fq].to_s)
+          .to include('Intersects')
+        expect(subject.add_spatial_params(solr_params)[:bq].to_s)
+          .to match(/.*IsWithin.*\^300/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds spatial parameters to search builder for better spatial searches. Pulled from Earthworks.
