### PR TITLE
make stanford icon default gray color

### DIFF
--- a/app/assets/stylesheets/icons/icons.scss
+++ b/app/assets/stylesheets/icons/icons.scss
@@ -25,6 +25,11 @@
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
 }
+
+.geoblacklight-stanford {
+  color: $gray-light;
+}
+
 .icon-graphbar {
     &:before {
         content: $icon-graphbar;


### PR DESCRIPTION
Sets Stanford icon to default gray color. The custom color is set in the geoblacklight gem [css](https://github.com/geoblacklight/geoblacklight/blob/01a76f7b8aa5f7dabc9c35ec6c634604d5124ecd/app/assets/stylesheets/geoblacklight/modules/icon-customization.scss#L8-L10). Closes #207.

<img width="373" alt="gray-icons" src="https://cloud.githubusercontent.com/assets/4650153/20109438/0dd29724-a5ae-11e6-99aa-d13b3b06d58b.png">
