### PR TITLE
sanborn maps have image data type

### DIFF
--- a/app/views/catalog/_featured_content.html.erb
+++ b/app/views/catalog/_featured_content.html.erb
@@ -4,7 +4,7 @@
       <h6 class="er_toc_tag" id="er-toc-id-2">Suggested Searches</h6>
     </div>
     <div class="grid-items">
-      <a href="/?f%5Blayer_geom_type_s%5D%5B%5D=Scanned+Map&q=Sanborn" class="grid-item">
+      <a href="/?f%5Blayer_geom_type_s%5D%5B%5D=Image&q=Sanborn" class="grid-item">
         <span class="icon-building"></span>
         <h1>Sanborn</h1>
         <p>Detailed fire insurance maps of cities and towns in New Jersey.</p>


### PR DESCRIPTION
Featured sanborn search filter returns [no results](https://maps.princeton.edu/?f%5Blayer_geom_type_s%5D%5B%5D=Scanned+Map&q=Sanborn) because data type has changed from scanned map to image.