### PR TITLE
use new mail server

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -67,7 +67,7 @@ Rails.application.configure do
   config.action_mailer.delivery_method = :smtp
 
   config.action_mailer.smtp_settings = {
-    address: 'dss.princeton.edu'
+    address: 'lib-ponyexpr.princeton.edu'
   }
   config.action_mailer.default_options = {
     from: 'no-reply@princeton.edu'


### PR DESCRIPTION
Advances #259. This new mail server will only work for emails to princeton.edu addresses until OIT opens up the firewall.