### PR TITLE
Removed the facet for the "Format" field within the CatalogController

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -111,7 +111,6 @@ class CatalogController < ApplicationController
     # config.add_facet_field Settings.FIELDS.PUBLISHER, label: 'Publisher', limit: 8, single: true
     # config.add_facet_field Settings.FIELDS.SPATIAL_COVERAGE, label: 'Place', limit: 8
     config.add_facet_field Settings.FIELDS.PART_OF, label: 'Collection', limit: 8
-    config.add_facet_field Settings.FIELDS.FILE_FORMAT, label: 'Format', limit: 8, single: true
 
     # Have BL send all facet field names to Solr, which has been the default
     # previously. Simply remove these lines if you'd rather use Solr request

--- a/spec/features/advanced_search_spec.rb
+++ b/spec/features/advanced_search_spec.rb
@@ -20,11 +20,12 @@ feature 'advanced search' do
       expect(page).to have_css "#op3_NOT[checked='checked']", count: 1
     end
     scenario 'advanced facets are carried over' do
-      visit '/?f_inclusive%5Bdc_format_s%5D%5B%5D=GeoTIFF&f_inclusive'\
-            '%5Bdc_format_s%5D%5B%5D=Paper&search_field=advanced'
+      visit '/?f_inclusive%5Blayer_geom_type_s%5D%5B%5D=Image'\
+            '&f_inclusive%5Blayer_geom_type_s%5D%5B%5D=Line&'\
+            'search_field=advanced'
       click_link 'Edit search'
-      expect(page).to have_css "option[value='GeoTIFF'][selected='selected']", count: 1
-      expect(page).to have_css "option[value='Paper'][selected='selected']", count: 1
+      expect(page).to have_css "option[value='Image'][selected='selected']", count: 1
+      expect(page).to have_css "option[value='Line'][selected='selected']", count: 1
     end
   end
 end


### PR DESCRIPTION
* Removed the facet for the "Format" field within the CatalogController
* Updated a feature spec to verify that the "Data Type" facets are carried over for advanced searches (previously this used the "Format" field)

Closes #309 