### PR TITLE
Suppresses bounding constraint values for searches

### DIFF
--- a/app/assets/stylesheets/shame-geo.scss
+++ b/app/assets/stylesheets/shame-geo.scss
@@ -45,4 +45,10 @@ li.bullet:hover {
     margin-bottom: 0.35em;
     margin-top: 1em;
     padding: 2px 0;
+
+    .appliedFilter {
+      .filterName.filterBlank:after {
+        content: none;
+      }
+    }
 }

--- a/app/helpers/pulmap_geoblacklight_helper.rb
+++ b/app/helpers/pulmap_geoblacklight_helper.rb
@@ -1,5 +1,22 @@
 module PulmapGeoblacklightHelper
   include GeoblacklightHelper
+  # Render a label/value constraint on the screen. Can be called
+  # by plugins and such to get application-defined rendering.
+  #
+  # Can pass in nil label if desired.
+  # @see Blacklight::RenderConstraintsHelperBehavior#render_constraint_element
+  #
+  # @param [String] label to display
+  # @param [String] value to display
+  # @param [Hash] options
+  # @option options [String] :remove url to execute for a 'remove' action
+  # @option options [Array<String>] :classes an array of classes to add to container span.
+  # @return [String]
+  def render_constraint_element(label, value, options = {})
+    value = nil if params[:bbox] && label == t('pulmap.search.bbox.label')
+    super(label, value, options)
+  end
+
   def document_available?
     (@document.public? && @document.available?) || (@document.same_institution? &&
                                                     user_signed_in? &&

--- a/app/views/catalog/_constraints_element.html.erb
+++ b/app/views/catalog/_constraints_element.html.erb
@@ -10,7 +10,7 @@
 <span class="btn-group appliedFilter constraint <%= options[:classes].join(" ") if options[:classes] %>">
   <span class="constraint-value btn btn-default btn-disabled">
     <% unless label.blank? %>
-      <span class="filterName"><%= label %></span>
+      <span class="filterName <%= 'filterBlank' if value.blank? %>"><%= label %></span>
     <% end %>
     <% unless value.blank? %>
       <%= content_tag :span, value, class: 'filterValue', title: value %>

--- a/config/locales/pulmap.en.yml
+++ b/config/locales/pulmap.en.yml
@@ -1,0 +1,5 @@
+en:
+  pulmap:
+    search:
+      bbox:
+        label: 'Bounding Box'

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -29,4 +29,13 @@ feature 'Search' do
     visit '/?f[dct_source_sm][]=princeton-1r66j405w&q='
     expect(page).to have_css '.document', count: 4
   end
+
+  feature 'spatial search' do
+    scenario 'When searching using a bbox constraint, hide the coordinates' do
+      visit '/catalog?bbox=-74.97447967529297%2040.237605%20-74.28783416748047%2040.446947'
+      expect(page).to have_css 'span.appliedFilter.constraint', count: 1
+      expect(page).to have_content 'Bounding Box'
+      expect(page).not_to have_content '-74.97447967529297 40.237605 -74.28783416748047 40.446947'
+    end
+  end
 end

--- a/spec/helpers/pulmap_geoblacklight_helper_spec.rb
+++ b/spec/helpers/pulmap_geoblacklight_helper_spec.rb
@@ -38,4 +38,26 @@ describe PulmapGeoblacklightHelper, type: :helper do
       end
     end
   end
+
+  describe '#render_constraint_element' do
+    context 'when a bounding box constraint is applied' do
+      let(:params) do
+        { bbox: '-43.9453125 04.214943 043.9453125 036.597889' }
+      end
+
+      before do
+        allow(controller).to receive(:params).and_return(params)
+      end
+
+      it 'does not render values for bounding box constraints' do
+        expect(helper.render_constraint_element('Bounding Box',\
+                                                '-43.9453125 04.214943 043.9453125 036.597889'))\
+          .not_to have_content('-43.9453125 04.214943 043.9453125 036.597889')
+      end
+
+      it 'renders other constaints' do
+        expect(helper.render_constraint_element('Data type', 'Polygon')).to have_content('Polygon')
+      end
+    end
+  end
 end

--- a/spec/views/catalog/_constraints_element.erb_spec.rb
+++ b/spec/views/catalog/_constraints_element.erb_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+describe 'catalog/_constraints_element.html.erb', type: :view do
+  context 'when no value is supplied' do
+    before do
+      render partial: 'catalog/constraints_element', locals: { label: 'my label', value: nil }
+    end
+
+    it 'does not render blank values' do
+      expect(rendered).not_to have_content 'my value'
+      expect(rendered).to have_css '.filterBlank'
+    end
+  end
+  context 'when a value is supplied' do
+    before do
+      render partial: 'catalog/constraints_element',\
+             locals: { label: 'my label', value: 'my value' }
+    end
+
+    it 'renders values' do
+      expect(rendered).to have_content 'my value'
+      expect(rendered).not_to have_css '.filterBlank'
+    end
+  end
+end


### PR DESCRIPTION
Resolves #311 by addressing the following:
- Ensuring that values rendered for the bounding box constraint are `nil`
- Ensuring that the <span> elements for constraints bear the `.filterBlank` class if the value is empty
- Ensuring that the Glyphicon is not rendered for constraint `<span>` elements without values