### PR TITLE
Replacing "Suggested Searches" with "Featured Content"

### DIFF
--- a/app/views/catalog/_featured_content.html.erb
+++ b/app/views/catalog/_featured_content.html.erb
@@ -1,7 +1,7 @@
 <div class="col-md-12">
   <section class="topics">
     <div class="line-behind-text">
-      <h6 class="er_toc_tag" id="er-toc-id-2">Suggested Searches</h6>
+      <h6 class="er_toc_tag" id="er-toc-id-2"><%= t('pulmap.search.topics.heading') %></h6>
     </div>
     <div class="grid-items">
       <a href="/?f%5Blayer_geom_type_s%5D%5B%5D=Image&q=Sanborn" class="grid-item">

--- a/config/locales/pulmap.en.yml
+++ b/config/locales/pulmap.en.yml
@@ -1,5 +1,7 @@
 en:
   pulmap:
     search:
+      topics:
+        heading: 'Featured Content'
       bbox:
         label: 'Bounding Box'

--- a/spec/views/catalog/_featured_content.erb_spec.rb
+++ b/spec/views/catalog/_featured_content.erb_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+describe 'catalog/_featured_content.html.erb', type: :view do
+  before do
+    render
+  end
+  it 'renders the default heading "Featured Content"' do
+    expect(rendered).to have_css '.topics .er_toc_tag'
+    expect(rendered).to have_content 'Featured Content'
+  end
+end


### PR DESCRIPTION
Resolves #296 and abstracts the "Featured Content" heading text in order to support i18n
