### PR TITLE
Links thumbnails to items within result sets

### DIFF
--- a/app/helpers/thumbnail_helper.rb
+++ b/app/helpers/thumbnail_helper.rb
@@ -1,19 +1,26 @@
 module ThumbnailHelper
   ##
+  # Returns the GeoBlacklight thumbnail linked to the item record
+  # @param document [SolrDocument]
+  # @param opts [Hash]
+  # @option opts [Int] :counter the index of the item in the result set.
+  # @return [String]
+  def gbl_thumbnail_img(document, opts = { counter: nil })
+    img_tag = gbl_thumbnail_img_tag(document)
+    link_to img_tag, url_for_document(document), document_link_params(document, opts)
+  end
+
+  ##
   # Returns html for displaying a geoblacklight thumbnail. If there isn't a
   # thumbnail url, a placeholder showing the geometry type is displayed. If there
   # is a thumbnail url, a placeholder is displayed along with an image tag. The
   # thumbnail image is then loaded asynchronously via javascript.
   # @param [SolrDocument]
   # @return [String]
-  def gbl_thumbnail_img(document)
+  def gbl_thumbnail_img_tag(document)
     url = document.thumbnail_url
-    if url
-      h = [content_tag(:img, nil, class: 'item-thumbnail', data: { aload: url.to_s })]
-      h << geoblacklight_icon(document['layer_geom_type_s'])
-    else
-      h = [geoblacklight_icon(document['layer_geom_type_s'])]
-    end
+    h = [geoblacklight_icon(document['layer_geom_type_s'])]
+    h.unshift content_tag(:img, nil, class: 'item-thumbnail', data: { aload: url.to_s }) if url
     safe_join h
   end
 end

--- a/app/views/catalog/_index_split_default.html.erb
+++ b/app/views/catalog/_index_split_default.html.erb
@@ -19,6 +19,6 @@
     </div>
   </div>
   <div class="col-xs-2 more-info-area thumbnail pull-right">
-    <%=gbl_thumbnail_img(document) %>
+    <%= gbl_thumbnail_img(document) %>
   </div>
 <% end %>

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -38,4 +38,10 @@ feature 'Search' do
       expect(page).not_to have_content '-74.97447967529297 40.237605 -74.28783416748047 40.446947'
     end
   end
+
+  scenario 'When searching, link the thumbnails in the results to the items' do
+    visit '/?q='
+    expect(page).to have_css '.document .row .thumbnail a'
+    expect(first('.document .row .thumbnail a')[:href]).to include('/catalog/')
+  end
 end

--- a/spec/helpers/thumbnail_helper_spec.rb
+++ b/spec/helpers/thumbnail_helper_spec.rb
@@ -1,25 +1,29 @@
 require 'rails_helper'
 
 describe ThumbnailHelper, type: :helper do
-  include GeoblacklightHelper
-
   let(:document) { SolrDocument.new(document_attributes) }
   let(:document_attributes) { { layer_geom_type_s: 'Polygon' } }
 
-  describe '#gbl_thumbnail_img' do
+  describe '#gbl_thumbnail_img_tag' do
     context 'document has a thumbnail url' do
+      before do
+        allow(document).to receive(:thumbnail_url).and_return('http://www.example.com/image.jpg')
+      end
+
       it 'returns a geoblacklight icon span and an image tag' do
-        allow(document).to receive('thumbnail_url').and_return('http://www.example.com/image.jpg')
-        html = Capybara.string(gbl_thumbnail_img(document))
+        html = Capybara.string(helper.gbl_thumbnail_img_tag(document))
         expect(html).to have_xpath("//img[@data-aload='http://www.example.com/image.jpg']")
         expect(html).to have_xpath("//span[contains(@class,'geoblacklight-polygon')]")
       end
     end
 
     context 'document does not have a thumbnail url' do
+      before do
+        allow(document).to receive(:thumbnail_url).and_return(nil)
+      end
+
       it 'returns a only geoblacklight icon span' do
-        allow(document).to receive('thumbnail_url').and_return(nil)
-        html = Capybara.string(gbl_thumbnail_img(document))
+        html = Capybara.string(helper.gbl_thumbnail_img_tag(document))
         expect(html).to have_no_xpath('//img')
         expect(html).to have_xpath("//span[contains(@class,'geoblacklight-polygon')]")
       end


### PR DESCRIPTION
Resolves #315 by linking thumbnails to items within result sets (and separating the functionality for generating thumbnail markup from the links to the items)