### PR TITLE
"Full screen" mode for ArcGIS Layer Items

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -85,13 +85,21 @@ LEAFLET:
         - 'Opacity'
         - 'Fullscreen'
     TILEDMAPLAYER:
-      <<: *opacity_control
+      CONTROLS:
+        - 'Opacity'
+        - 'Fullscreen'
     FEATURELAYER:
-      <<: *opacity_control
+      CONTROLS:
+        - 'Opacity'
+        - 'Fullscreen'
     DYNAMICMAPLAYER:
-      <<: *opacity_control
+      CONTROLS:
+        - 'Opacity'
+        - 'Fullscreen'
     IMAGEMAPLAYER:
-      <<: *opacity_control
+      CONTROLS:
+        - 'Opacity'
+        - 'Fullscreen'
 
 THUMBNAIL:
   USE_DCT_REFS: false

--- a/spec/helpers/pulmap_geoblacklight_helper_spec.rb
+++ b/spec/helpers/pulmap_geoblacklight_helper_spec.rb
@@ -6,6 +6,8 @@ describe PulmapGeoblacklightHelper, type: :helper do
   describe '#viewer_container' do
     let(:document) { SolrDocument.new(document_attributes) }
     let(:references_field) { Settings.FIELDS.REFERENCES }
+    let(:rights_field) { Settings.FIELDS.RIGHTS }
+
     context 'with iiif manifest' do
       let(:manifest_viewer) { double }
       let(:document_attributes) do
@@ -22,6 +24,7 @@ describe PulmapGeoblacklightHelper, type: :helper do
         helper.viewer_container
       end
     end
+
     context 'missing iiif manifest' do
       let(:leaflet_viewer) { double }
       let(:document_attributes) do
@@ -35,6 +38,110 @@ describe PulmapGeoblacklightHelper, type: :helper do
         assign(:document, document)
         expect(helper).to receive(:leaflet_viewer)
         helper.viewer_container
+      end
+    end
+
+    context 'with an ArcGIS Tiled Map Layer' do
+      let(:leaflet_viewer) { double }
+      let(:document_attributes) do
+        {
+          references_field => {
+            'urn:x-esri:serviceType:ArcGIS#TiledMapLayer' =>
+              'https://example.edu/arcgis/rest/services/Specialty/Soil_Survey_Map/MapServer'
+          }.to_json,
+          rights_field => 'Public'
+        }
+      end
+
+      before do
+        allow(helper).to receive(:geoblacklight_basemap).and_return('esri')
+        assign(:document, document)
+      end
+
+      it 'renders a Leaflet container with the fullscreen option' do
+        node = Capybara.string(helper.viewer_container)
+        div = node.first('div')
+        expect(div[:'data-leaflet-options']).to include(
+          '"TILEDMAPLAYER":{"CONTROLS":["Opacity","Fullscreen"]}'
+        )
+      end
+    end
+
+    context 'with an ArcGIS Feature Layer' do
+      let(:leaflet_viewer) { double }
+      let(:document_attributes) do
+        {
+          references_field => {
+            'urn:x-esri:serviceType:ArcGIS#FeatureLayer' =>
+              'https://example.edu/arcgis/rest/services/Fire_Station_Areas/FeatureServer'
+          }.to_json,
+          rights_field => 'Public'
+        }
+      end
+
+      before do
+        allow(helper).to receive(:geoblacklight_basemap).and_return('esri')
+        assign(:document, document)
+      end
+
+      it 'renders a Leaflet container with the fullscreen option' do
+        node = Capybara.string(helper.viewer_container)
+        div = node.first('div')
+        expect(div[:'data-leaflet-options']).to include(
+          '"FEATURELAYER":{"CONTROLS":["Opacity","Fullscreen"]}'
+        )
+      end
+    end
+
+    context 'with an ArcGIS Dynamic Map Layer' do
+      let(:leaflet_viewer) { double }
+      let(:document_attributes) do
+        {
+          references_field => {
+            'urn:x-esri:serviceType:ArcGIS#DynamicMapLayer' =>
+              'https://example.edu/arcgis/rest/services/Geology/Glacial_Boundaries/MapServer'
+          }.to_json,
+          rights_field => 'Public'
+        }
+      end
+
+      before do
+        allow(helper).to receive(:geoblacklight_basemap).and_return('esri')
+        assign(:document, document)
+      end
+
+      it 'renders a Leaflet container with the fullscreen option' do
+        node = Capybara.string(helper.viewer_container)
+        div = node.first('div')
+        expect(div[:'data-leaflet-options']).to include(
+          '"DYNAMICMAPLAYER":{"CONTROLS":["Opacity","Fullscreen"]}'
+        )
+      end
+    end
+
+    context 'with an ArcGIS Image Map Layer' do
+      let(:leaflet_viewer) { double }
+      let(:document_attributes) do
+        {
+          references_field => {
+            'urn:x-esri:serviceType:ArcGIS#ImageMapLayer' =>
+              'https://example.edu/arcgis/rest/services/NAIP_2011/NAIP_2011_Dynamic/ImageServer'
+          }.to_json,
+          rights_field => 'Public'
+        }
+      end
+
+      before do
+        allow(helper).to receive(:geoblacklight_basemap).and_return('esri')
+        assign(:document, document)
+      end
+
+      it 'renders a Leaflet container with the fullscreen option' do
+        node = Capybara.string(helper.viewer_container)
+        div = node.first('div')
+        expect(div[:'data-leaflet-options']).to include(
+          '"IMAGEMAPLAYER":{"CONTROLS":["Opacity","Fullscreen"]}'
+        )
       end
     end
   end


### PR DESCRIPTION
Resolves #321 by ensuring that the Leaflet "full screen" option enabled for Items with ArcGIS Map Layer sources