### PR TITLE
adjust search results metadata layout

### DIFF
--- a/app/assets/stylesheets/components/results.scss
+++ b/app/assets/stylesheets/components/results.scss
@@ -32,3 +32,12 @@
 .params {
     display: inline-block;
 }
+
+.index_title {
+  white-space: normal;
+}
+
+.document-wrapper {
+  width: calc(100% - 95px);
+  display: inline-block;
+}

--- a/app/assets/stylesheets/components/thumbnail.scss
+++ b/app/assets/stylesheets/components/thumbnail.scss
@@ -3,8 +3,11 @@
   border-radius: 0;
   padding: 0;
   max-width: 85px;
+  margin-bottom: 3px;
+  margin-top: 7px;
   background-color: transparent;
   border: none;
+  float: right;
 }
 
 // thumbnail image
@@ -48,3 +51,8 @@
 }
 
 [data-aload] { background-image: none !important; }
+
+.more-info-area {
+  width: 90px;
+  float: right;
+}

--- a/app/presenters/geoblacklight/document_presenter.rb
+++ b/app/presenters/geoblacklight/document_presenter.rb
@@ -1,0 +1,23 @@
+module Geoblacklight
+  ##
+  # Adds custom functionality for Geoblacklight document presentation
+  class DocumentPresenter < Blacklight::IndexPresenter
+    include ActionView::Helpers::OutputSafetyHelper
+    ##
+    # Presents configured index fields in search results. Passes values through
+    # configured helper_method. Multivalued fields separated by presenter
+    # field_value_separator (default: comma). Fields separated by period.
+    # @return [String]
+    def index_fields_display
+      fields_values = []
+      @configuration.index_fields.each do |field_name, _|
+        val = field_value(field_name)
+        unless val.blank?
+          val += '.' unless val.end_with?('.')
+          fields_values << val
+        end
+      end
+      safe_join(fields_values, ' ')
+    end
+  end
+end

--- a/app/views/catalog/_index_split_default.html.erb
+++ b/app/views/catalog/_index_split_default.html.erb
@@ -1,24 +1,27 @@
 <% # header bar for doc items in index view -%>
 <%= content_tag :div, class: 'documentHeader row', data: { layer_id: document.id, bbox: document.bounding_box_as_wsen } do %>
-  <div class='status-icons'>
-    <%= render partial: 'header_icons', locals: { document: document } %>
-  </div>
-  <h3 class="index_title col-sm-9s cosl-lg-10 text-span">
-    <% counter = document_counter_with_offset(document_counter) %>
-    <span class="document-counter">
-      <%= t('blacklight.search.documents.counter', :counter => counter) if counter %>
-    </span>
-    <%= link_to_document document, document_show_link_field(document), counter: counter, title: document[blacklight_config.index.title_field] %>
-  </h3>
-
-  <div class='col-xs-10'>
-    <div>
-      <small>
-        <%= geoblacklight_present(:index_fields_display, document) %>
-      </small>
+    <div class='more-info-area'>
+      <div class='status-icons'>
+        <%= render partial: 'header_icons', locals: { document: document } %>
+      </div>
+      <div class="thumbnail">
+        <%= gbl_thumbnail_img(document) %>
+      </div>
     </div>
-  </div>
-  <div class="col-xs-2 more-info-area thumbnail pull-right">
-    <%= gbl_thumbnail_img(document) %>
+  <div class="document-wrapper">
+    <h3 class="index_title col-sm-9s cosl-lg-10 text-span">
+      <% counter = document_counter_with_offset(document_counter) %>
+      <span class="document-counter">
+        <%= t('blacklight.search.documents.counter', :counter => counter) if counter %>
+      </span>
+      <%= link_to_document document, document_show_link_field(document), counter: counter, title: document[blacklight_config.index.title_field] %>
+    </h3>
+    <div class='col-xs-12'>
+      <div>
+        <small>
+          <%= geoblacklight_present(:index_fields_display, document) %>
+        </small>
+      </div>
+    </div>
   </div>
 <% end %>


### PR DESCRIPTION
Don't truncate titles.
Reorder the index fields to author, publisher, description.
Reduces padding below thumbnail to save vertical space.
Allow html content to render without escaping.
Closes #324 
Before:
<img width="732" alt="before" src="https://user-images.githubusercontent.com/4650153/28479103-035b490a-6e29-11e7-99bc-cba0a010356b.png">
After:
<img width="753" alt="after" src="https://user-images.githubusercontent.com/4650153/28479102-01f39784-6e29-11e7-9ced-205c6f122a95.png">