### PR TITLE
Hide constraints when query parameter is empty

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -36,6 +36,24 @@ module ApplicationHelper
     end
   end
 
+  def hide_constraints?
+    skip_params = constraint_params_to_skip
+    skip_params << 'q' if params[:q] && params[:q].empty?
+    params.reject { |p| skip_params.include?(p) }.empty?
+  end
+
+  def constraint_params_to_skip
+    %w(
+      page
+      per_page
+      search_field
+      sort
+      controller
+      action
+      utf8
+    )
+  end
+
   ##
   # Gets current layout for use in rendering partials
   # @return [String] item, index, home, or default

--- a/app/views/catalog/_constraints.html.erb
+++ b/app/views/catalog/_constraints.html.erb
@@ -2,7 +2,7 @@
   <%= render partial: 'facets' %>
 </div>
 
-<% if query_has_constraints? %>
+<% if query_has_constraints? && !hide_constraints? %>
     <div id="appliedParams" class="clearfix constraints-container">
       <div class="params">
         <span class="constraints-label"><%= t('blacklight.search.filters.title') %></span>

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -44,4 +44,11 @@ feature 'Search' do
     expect(page).to have_css '.document .row .thumbnail a'
     expect(first('.document .row .thumbnail a')[:href]).to include('/catalog/')
   end
+
+  feature 'constraints' do
+    scenario 'when searching with an empty query parameter' do
+      visit '/?utf8=true&search_field=all_fields&q='
+      expect(page).not_to have_content('You searched for')
+    end
+  end
 end


### PR DESCRIPTION
Hides constraints when query parameter is empty and there are no other constraints.