### PR TITLE
Removes the UV title for records and fixes History API conflicts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -79,6 +79,5 @@ gem 'twitter-typeahead-rails', '0.11.1.pre.corejavascript'
 gem 'blacklight_range_limit'
 gem 'blacklight_advanced_search'
 gem 'sneakers'
-
-#  jquery multiselect plugin for advanced search
-gem 'chosen-rails'
+gem 'chosen-rails' #  jquery multiselect plugin for advanced search
+gem 'pul_uv_rails', git: 'https://github.com/pulibrary/pul_uv_rails', branch: 'master'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,10 @@
+GIT
+  remote: https://github.com/pulibrary/pul_uv_rails
+  revision: e3dd14a13aa8468751dd5d870b3647bafc0db9ff
+  branch: master
+  specs:
+    pul_uv_rails (2.0.1)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -400,6 +407,7 @@ DEPENDENCIES
   omniauth-cas
   pg
   poltergeist
+  pul_uv_rails!
   puma (~> 3.0)
   rails (~> 5.0)
   rails-controller-testing
@@ -420,4 +428,4 @@ DEPENDENCIES
   xray-rails
 
 BUNDLED WITH
-   1.14.6
+   1.15.3

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,22 +12,21 @@
 //
 //= require jquery
 //= require 'blacklight_advanced_search'
-
 //= require chosen-jquery
-
 //= require jquery_ujs
 //= require twitter/typeahead.min
 //= require aload
 
 // Required by Blacklight
 //= require blacklight/blacklight
-//= require_tree .
-
 //= require 'blacklight_range_limit'
 
 //= require modernizr
 //= require bootstrap-toggle
 
+//= require_tree .
+
+//= stub modules/results
 //= require modules/map
 //= require modules/thumbnail
 //= require modules/advanced_chosen

--- a/app/assets/javascripts/modules/plum_viewer_loader.js.coffee
+++ b/app/assets/javascripts/modules/plum_viewer_loader.js.coffee
@@ -3,17 +3,21 @@ jQuery ->
 class PlumViewerLoader
   constructor: (@element) ->
     return unless this.element.length > 0
-    this.build_viewer(this.manifest())
+    this.build_viewer(this.manifest(), this.config(), this.src())
   manifest: ->
     this.element.data("manifest")
-  build_viewer: (manifest) ->
+  config: ->
+    this.element.data("config")
+  src: ->
+    this.element.data("src")
+  build_viewer: (manifest, config, src) ->
     element = $(document.createElement('div'))
     element.addClass('uv')
-    element.attr('data-config', "https://plum.princeton.edu/uv_config.json")
+    element.attr('data-config', config)
     element.attr('data-uri', manifest)
     script_tag = $(document.createElement('script'))
     script_tag.attr('id', 'embedUV')
-    script_tag.attr('src', "https://plum.princeton.edu/universalviewer/dist/uv-2.0.1/lib/embed.js")
+    script_tag.attr('src', src)
     this.element.append(element)
     this.element.append(script_tag)
     this.element.before($("<hr class='clear'/>"))

--- a/app/assets/javascripts/uv/uv_config.json
+++ b/app/assets/javascripts/uv/uv_config.json
@@ -1,0 +1,15 @@
+{
+  "modules": {
+    "pagingHeaderPanel": {
+      "options": {
+        "autoCompleteBoxEnabled": false,
+        "imageSelectionBoxEnabled": true
+      }
+    },
+    "seadragonCenterPanel": {
+      "options": {
+        "titleEnabled": false
+      }
+    }
+  }
+}

--- a/app/helpers/pulmap_geoblacklight_helper.rb
+++ b/app/helpers/pulmap_geoblacklight_helper.rb
@@ -53,6 +53,10 @@ module PulmapGeoblacklightHelper
   def manifest_viewer
     content_tag(:div, nil,
                 id: 'view',
-                data: { manifest: @document.references.references(:iiif_manifest).endpoint })
+                data: {
+                  manifest: @document.references.references(:iiif_manifest).endpoint,
+                  config: asset_url('uv/uv_config.json'),
+                  src: PulUvRails::UniversalViewer.instance.viewer_link
+                })
   end
 end

--- a/app/views/catalog/_search_results.html.erb
+++ b/app/views/catalog/_search_results.html.erb
@@ -1,3 +1,4 @@
+<%= javascript_include_tag 'modules/results' %>
 <h2 class="sr-only top-content-title"><%= t('blacklight.search.search_results_header') %></h2>
 
 <% @page_title = t('blacklight.search.title', :application_name => application_name) %>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -22,7 +22,7 @@ Rails.application.configure do
 
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.
-  config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
+  config.public_file_server.enabled = true
 
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = :uglifier

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -8,4 +8,4 @@ Rails.application.config.assets.version = '1.0'
 
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
-Rails.application.config.assets.precompile += %w( print.css )
+Rails.application.config.assets.precompile += %w( print.css modules/results.js )

--- a/spec/features/manifest_viewer_spec.rb
+++ b/spec/features/manifest_viewer_spec.rb
@@ -5,4 +5,9 @@ feature 'IIIF Universal Viewer' do
     visit solr_document_path('princeton-8c97ks94m')
     expect(page).to have_css('#view')
   end
+
+  scenario 'does not render record titles' do
+    visit solr_document_path('princeton-8c97ks94m')
+    expect(page).not_to have_css('#app .mainPanel .centerPanel > .title')
+  end
 end


### PR DESCRIPTION
As within #374 :
> Resolves #285 by providing a local config. JSON object for the UniversalViewer in order to hide the title and resolves #377 by using a local build of the UV to provide the viewing interface

However, this also ensures that JavaScript functionality which conflicts with the listening of Window events and manipulates the browser History API are isolated to the search results interface.