### PR TITLE
Renders the Download Credit Request Page only for Princeton Items

### DIFF
--- a/app/views/catalog/_downloads.html.erb
+++ b/app/views/catalog/_downloads.html.erb
@@ -1,12 +1,18 @@
 <% document ||= @document %>
-<% if document_downloadable? %>
-  <%= link_to 'Download',
-              document_action_path(document_action_config, (local_assigns.has_key?(:url_opts) ? url_opts : {}).merge(({id: document} if document) || {})),
-              id: document_action_config.fetch(:id, "#{document_action_config.key}Link"),
-              class: 'nav-link' %>
-
-<% elsif document.restricted? && document.same_institution? %>
-  <div class='panel-body'>
-    <%= link_to t('geoblacklight.tools.login_to_view'), user_cas_omniauth_authorize_path %>
-  </div>
+<% if document.same_institution? %>
+  <% if document_downloadable? %>
+    <%= link_to 'Download',
+                document_action_path(document_action_config, (local_assigns.has_key?(:url_opts) ? url_opts : {}).merge(({id: document} if document) || {})),
+                id: document_action_config.fetch(:id, "#{document_action_config.key}Link"),
+                class: 'nav-link' %>
+  <% elsif document.restricted? %>
+    <div class='panel-body'>
+      <%= link_to t('geoblacklight.tools.login_to_view'), user_cas_omniauth_authorize_path %>
+    </div>
+  <% end %>
+<% elsif document_downloadable? %>
+  <div class='btn-group' itemprop='distribution' itemscope='itemscope' itemtype='http://schema.org/DataDownload'>
+	  <%= render 'downloads_primary' %>
+	  <%= render 'downloads_secondary' %>
+	</div>
 <% end %>

--- a/spec/features/shapefile_downloads_spec.rb
+++ b/spec/features/shapefile_downloads_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+feature 'Shapefile (and derivative) Downloads' do
+  scenario 'renders the the link to the download credit request page for Princeton Documents' do
+    visit solr_document_path('princeton-8c97ks94m')
+    expect(page).to have_css '#downloadsLink'
+  end
+
+  scenario 'renders the the authentication link for access-restricted Princeton Documents' do
+    visit solr_document_path('princeton-3x816p22x')
+    expect(page).to have_link 'Login to view and download'
+  end
+
+  scenario 'renders the panel containing the download links for non-Princeton Documents' do
+    visit solr_document_path('stanford-cz128vq0535')
+    expect(page).to have_link 'Download Shapefile'
+  end
+end


### PR DESCRIPTION
Resolves #361 by ensuring that the download credit request page is offered only for items for which Princeton University is the holding institution