### PR TITLE
Properly format bbox constraint label

### DIFF
--- a/app/helpers/advanced_helper.rb
+++ b/app/helpers/advanced_helper.rb
@@ -196,10 +196,7 @@ module BlacklightAdvancedSearch
     # @return [String]
     def render_constraint_element(label, value, options = {})
       if params[:bbox]
-        if label == 'Bounding Box'
-          value = nil
-          label = t('geoblacklight.bbox_label')
-        end
+        value = nil if label == t('geoblacklight.bbox_label')
       end
       super(label, value, options)
     end

--- a/spec/helpers/advanced_helper_spec.rb
+++ b/spec/helpers/advanced_helper_spec.rb
@@ -12,7 +12,7 @@ describe BlacklightAdvancedSearch::RenderConstraintsOverride, type: :helper do
       end
 
       it 'does not render values for bounding box constraints' do
-        expect(helper.render_constraint_element('Bounding Box',\
+        expect(helper.render_constraint_element('Current Map View',\
                                                 '-43.9453125 04.214943 043.9453125 036.597889'))\
           .not_to have_content('-43.9453125 04.214943 043.9453125 036.597889')
       end


### PR DESCRIPTION
Fixes regression with bbox constrain label formatting. Bounding box constraint should not show value.