### PR TITLE
Increase facet dropdown width

### DIFF
--- a/app/assets/stylesheets/components/facets.scss
+++ b/app/assets/stylesheets/components/facets.scss
@@ -289,6 +289,7 @@ ul.facet-values {
   }
   ul.dropdown-menu {
     z-index: 999;
+    min-width: 200px;
   }
 }
 


### PR DESCRIPTION
Increase facet dropdown width to reduce text overflow.

<img width="168" alt="screenshot 2017-08-28 17 25 09" src="https://user-images.githubusercontent.com/784196/29796281-e17becf8-8c15-11e7-8511-f5014d99dad4.png">
