### PR TITLE
Proxy restricted Princeton geoserver layers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -82,3 +82,4 @@ gem 'sneakers'
 
 #  jquery multiselect plugin for advanced search
 gem 'chosen-rails'
+gem 'rails-reverse-proxy'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -223,6 +223,8 @@ GEM
     public_suffix (2.0.5)
     puma (3.9.1)
     rack (2.0.3)
+    rack-proxy (0.6.2)
+      rack
     rack-test (0.6.3)
       rack (>= 1.0)
     rails (5.1.2)
@@ -246,6 +248,11 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.0.3)
       loofah (~> 2.0)
+    rails-reverse-proxy (0.9.1)
+      addressable
+      rack
+      rack-proxy
+      rails
     railties (5.1.2)
       actionpack (= 5.1.2)
       activesupport (= 5.1.2)
@@ -403,6 +410,7 @@ DEPENDENCIES
   puma (~> 3.0)
   rails (~> 5.0)
   rails-controller-testing
+  rails-reverse-proxy
   rsolr (~> 1.1.1)
   rspec-rails (~> 3.5.0)
   rubocop (~> 0.42.0)
@@ -420,4 +428,4 @@ DEPENDENCIES
   xray-rails
 
 BUNDLED WITH
-   1.14.6
+   1.15.3

--- a/app/controllers/geoserver_controller.rb
+++ b/app/controllers/geoserver_controller.rb
@@ -1,0 +1,15 @@
+class GeoserverController < ApplicationController
+  include ReverseProxy::Controller
+
+  def index
+    reverse_proxy Settings.PRINCETON_GEOSERVER_URL, headers: headers
+  end
+
+  private
+
+  def headers
+    {
+      'Authorization' => Settings.PROXY_GEOSERVER_AUTH
+    }
+  end
+end

--- a/app/models/concerns/wms_rewrite_concern.rb
+++ b/app/models/concerns/wms_rewrite_concern.rb
@@ -1,0 +1,20 @@
+module WmsRewriteConcern
+  extend Geoblacklight::SolrDocument
+
+  def viewer_endpoint
+    if princeton_restricted?
+      # replace wms prefix with cas authed proxy
+      super.gsub(Settings.PRINCETON_GEOSERVER_URL, Settings.PROXY_GEOSERVER_URL)
+    else
+      super
+    end
+  end
+
+  def princeton_restricted?
+    princeton? && restricted?
+  end
+
+  def princeton?
+    fetch(:dct_provenance_s, '').casecmp('princeton').zero?
+  end
+end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -5,6 +5,7 @@ class SolrDocument
   include ThumbnailConcern
   include GeomonitorConcern
   include SanbornConcern
+  include WmsRewriteConcern
 
   # self.unique_key = 'id'
   self.unique_key = 'layer_slug_s'

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -10,7 +10,7 @@ set :rails_env, 'production'
 # server 'example.com', user: 'deploy', roles: %w{app web}, other_property: :other_value
 # server 'db.example.com', user: 'deploy', roles: %w{db}
 
-server 'maps', user: 'deploy', roles: %w(web app db)
+server 'maps1', user: 'deploy', roles: %w(web app db)
 
 # role-based syntax
 # ==================

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,4 +48,8 @@ Rails.application.routes.draw do
   resources :download, only: [:show]
 
   resources :suggest, only: :index, defaults: { format: 'json' }
+
+  authenticate :user do
+    match 'geoserver/restricted/*path' => 'geoserver#index', via: [:get]
+  end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -35,6 +35,10 @@ FIELDS:
 GEOMONITOR_TOLERANCE: 0.8
 INSTITUTION: 'Princeton'
 
+PRINCETON_GEOSERVER_URL: <%= ENV['PRINCETON_GEOSERVER_URL'] || "https://geoserver.princeton.edu" %>
+PROXY_GEOSERVER_URL: <%= ENV['PROXY_GEOSERVER_URL'] || "http://localhost:3000" %>
+PROXY_GEOSERVER_AUTH: <%= ENV['PROXY_GEOSERVER_AUTH'] %>
+
 # Metadata shown in tool panel
 METADATA_SHOWN:
   - 'fgdc'

--- a/spec/controllers/geoserver_controller_spec.rb
+++ b/spec/controllers/geoserver_controller_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+describe GeoserverController, type: :controller do
+  describe '#index' do
+    it 'initiates a reverse proxy with headers' do
+      expect(controller).to receive(:reverse_proxy).with(anything, hash_including(:headers))
+      controller.index
+    end
+  end
+end

--- a/spec/features/geoserver_spec.rb
+++ b/spec/features/geoserver_spec.rb
@@ -1,0 +1,8 @@
+require 'rails_helper'
+
+feature 'geoserver proxy' do
+  scenario 'proxy requires authentication' do
+    visit '/geoserver/restricted/wms'
+    expect(current_path).to eq user_session_path
+  end
+end

--- a/spec/models/concerns/wms_rewrite_concern_spec.rb
+++ b/spec/models/concerns/wms_rewrite_concern_spec.rb
@@ -1,0 +1,63 @@
+require 'rails_helper'
+
+describe WmsRewriteConcern do
+  let(:document) { SolrDocument.new(document_attributes) }
+  describe 'viewer_endpoint' do
+    context 'when princeton and restricted' do
+      let(:document_attributes) do
+        {
+          dct_provenance_s: 'Princeton',
+          dc_rights_s: 'Restricted',
+          dct_references_s: {
+            'http://www.opengis.net/def/serviceType/ogc/wms' => 'https://geoserver.princeton.edu/restricted/geoserver/wms'
+          }.to_json
+        }
+      end
+      it 'rewrites url' do
+        expect(document.viewer_endpoint).to eq 'http://localhost:3000/restricted/geoserver/wms'
+      end
+    end
+    context 'when not princeton or public' do
+      let(:document_attributes) do
+        {
+          dct_provenance_s: 'Stanford',
+          dc_rights_s: 'Restricted',
+          dct_references_s: {
+            'http://www.opengis.net/def/serviceType/ogc/wms' => 'http://www.example.com/geoserver/wms'
+          }.to_json
+        }
+      end
+      it 'does not rewrite url' do
+        expect(document.viewer_endpoint).to eq 'http://www.example.com/geoserver/wms'
+      end
+    end
+  end
+  describe 'princeton_restricted?' do
+    context 'when princeton and restricted' do
+      let(:document_attributes) { { dct_provenance_s: 'Princeton', dc_rights_s: 'Restricted' } }
+      it 'identifies restricted princeton documents' do
+        expect(document.princeton_restricted?).to be_truthy
+      end
+    end
+    context 'when princeton and public' do
+      let(:document_attributes) { { dct_provenance_s: 'Princeton', dc_rights_s: 'Public' } }
+      it 'requires both conditions' do
+        expect(document.princeton_restricted?).to be_falsey
+      end
+    end
+  end
+  describe 'princeton?' do
+    context 'when princeton' do
+      let(:document_attributes) { { dct_provenance_s: 'Princeton' } }
+      it 'identifies princeton documents' do
+        expect(document.princeton?).to be_truthy
+      end
+    end
+    context 'when non-princeton' do
+      let(:document_attributes) { { dct_provenance_s: 'Stanford' } }
+      it 'identifies princeton documents' do
+        expect(document.princeton?).to be_falsey
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Sets up an authenticated reverse proxy for viewing restricted Geoserver layers.
- Proxy passes encoded basic auth credentials in the request header. Format is "Basic" + base64-encoded(username:password). E.g. "Basic DFzeu1TpAQVcgO21DCKrBjE2TipKSfv73JlzHn=="
- Rewrites wms viewer endpoint URLs for restricted Princeton datasets. Rewritten urls point to reverse proxy. Allows authenticated users to preview restricted datasets without a second round of Geoserver authentication. 

Closes #413