### PR TITLE
Use sidekiq for background jobs

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -48,6 +48,7 @@ Metrics/LineLength:
     # TODO: Refactor add_show_tools_partial procs.
     - 'app/controllers/catalog_controller.rb'
     - 'app/helpers/advanced_helper.rb'
+    - 'config/deploy.rb'
     - 'lib/tasks/ci.rake'
     - 'lib/tasks/thumbnails.rake'
     - 'spec/lib/thumbnail_spec.rb'
@@ -74,6 +75,10 @@ Style/StringLiterals:
 Naming/PredicateName:
   Exclude:
     - 'app/controllers/catalog_controller.rb'
+
+Rails/Output:
+  Exclude:
+    - 'config/deploy.rb'
 
 RSpec/DescribeClass:
   Exclude:

--- a/Gemfile
+++ b/Gemfile
@@ -80,6 +80,7 @@ gem 'pul_uv_rails', git: 'https://github.com/pulibrary/pul_uv_rails', branch: 'm
 gem 'rails-reverse-proxy'
 gem 'rsolr', '~> 1.1.1'
 gem 'rspec-rails', '~> 3.5.0'
+gem 'sidekiq'
 gem 'simple_form'
 gem 'sneakers'
 gem 'solr_wrapper'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,6 +119,7 @@ GEM
     config (1.4.0)
       activesupport (>= 3.0)
       deep_merge (~> 1.1.1)
+    connection_pool (2.2.1)
     coveralls (0.8.21)
       json (>= 1.8, < 3)
       simplecov (~> 0.14.1)
@@ -249,6 +250,8 @@ GEM
     public_suffix (2.0.5)
     puma (3.9.1)
     rack (2.0.3)
+    rack-protection (2.0.0)
+      rack
     rack-proxy (0.6.2)
       rack
     rack-test (0.6.3)
@@ -291,6 +294,7 @@ GEM
     rb-fsevent (0.10.2)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
+    redis (4.0.1)
     ref (2.0.0)
     responders (2.4.0)
       actionpack (>= 4.2.0, < 5.3)
@@ -343,6 +347,11 @@ GEM
       tilt (>= 1.1, < 3)
     serverengine (1.5.11)
       sigdump (~> 0.2.2)
+    sidekiq (5.0.5)
+      concurrent-ruby (~> 1.0)
+      connection_pool (~> 2.2, >= 2.2.0)
+      rack-protection (>= 1.5.0)
+      redis (>= 3.3.4, < 5)
     sigdump (0.2.4)
     simple_form (3.5.0)
       actionpack (> 4, < 5.2)
@@ -452,6 +461,7 @@ DEPENDENCIES
   rubocop (~> 0.51.0)
   rubocop-rspec (~> 1.20)
   sass-rails (~> 5.0)
+  sidekiq
   simple_form
   sneakers
   solr_wrapper

--- a/config/application.rb
+++ b/config/application.rb
@@ -9,11 +9,11 @@ Bundler.require(*Rails.groups)
 module Pulmap
   class Application < Rails::Application
     config.cache_store = :file_store, Rails.root.join("tmp", "thumbnails")
-    config.active_job.queue_adapter = :async
-    config.active_job.queue_adapter = ActiveJob::QueueAdapters::AsyncAdapter.new \
-      min_threads: 1,
-      max_threads: 2 * Concurrent.processor_count,
-      idletime: 600.seconds
+    config.active_job.queue_adapter = if Rails.env == "production"
+                                        :sidekiq
+                                      else
+                                        :async
+                                      end
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.

--- a/config/application.rb
+++ b/config/application.rb
@@ -8,6 +8,8 @@ Bundler.require(*Rails.groups)
 
 module Pulmap
   class Application < Rails::Application
+    require 'sidekiq_chart'
+
     config.cache_store = :file_store, Rails.root.join("tmp", "thumbnails")
     config.active_job.queue_adapter = if Rails.env == "production"
                                         :sidekiq

--- a/lib/sidekiq_chart.rb
+++ b/lib/sidekiq_chart.rb
@@ -1,0 +1,63 @@
+require 'sidekiq/api'
+
+class SidekiqChart
+  def render
+    chart = ""
+    sidekiq_data.each_key do |k|
+      chart << build_chart_line(k)
+    end
+
+    chart
+  end
+
+  private
+
+  def build_chart_line(job_type)
+    length = sidekiq_data[job_type] / scale
+    line = job_type.to_s.rjust(10)
+    line << "  #{sidekiq_data[job_type]}".rjust(7)
+    line << "      #{chart_bar(length)}"
+    line << "\n"
+    line << "\n"
+    line
+  end
+
+  def chart_bar(length)
+    "\e[44m \e[0m" * length
+  end
+
+  def dead_set
+    Sidekiq::DeadSet.new
+  end
+
+  def retry_set
+    Sidekiq::RetrySet.new
+  end
+
+  def scale
+    max_bar_length = 100.0
+    value = sidekiq_data.values.max / max_bar_length
+
+    # return 1 instead of 0.0 to avoid a NaN error
+    value == 0.0 ? 1 : value
+  end
+
+  def sidekiq_data
+    {
+      Busy: workers.size,
+      Enqueued: stats.enqueued,
+      Processed: stats.processed,
+      Failed: stats.failed,
+      Retries: retry_set.size,
+      Dead: dead_set.size
+    }
+  end
+
+  def stats
+    Sidekiq::Stats.new
+  end
+
+  def workers
+    Sidekiq::Workers.new
+  end
+end

--- a/lib/tasks/sidekiq.rake
+++ b/lib/tasks/sidekiq.rake
@@ -1,0 +1,26 @@
+namespace :sidekiq do
+  desc 'Show sidekiq stats'
+  task stats: :environment do
+    chart_builder = SidekiqChart.new
+    loop do
+      begin
+        chart = chart_builder.render
+        puts "\e[H\e[2J"
+        puts chart
+        sleep 5
+      rescue Interrupt
+        break
+      end
+    end
+  end
+  desc 'Clear queues'
+  task clear_queues: :environment do
+    Sidekiq::Queue.new.clear
+    Sidekiq::RetrySet.new.clear
+    Sidekiq::DeadSet.new.clear
+  end
+  desc 'Clear stats'
+  task clear_stats: :environment do
+    Sidekiq::Stats.new.reset
+  end
+end

--- a/lib/tasks/thumbnails.rake
+++ b/lib/tasks/thumbnails.rake
@@ -11,7 +11,7 @@ namespace :pulmap do
         document = Geoblacklight::SolrDocument.find(args[:doc_id])
         raise Blacklight::Exceptions::RecordNotFound if document[:layer_slug_s] != args[:doc_id]
         if !Rails.cache.exist?("thumbnails/#{args[:doc_id]}") || args[:override_existing]
-          CacheThumbnailJob.perform_now(document.to_h)
+          CacheThumbnailJob.perform_later(document.to_h)
         end
       end
     end
@@ -33,7 +33,7 @@ namespace :pulmap do
           puts "#{document[:layer_slug_s]} (#{doc_counter}/#{num_found})"
           begin
             if !Rails.cache.exist?("thumbnails/#{document[:layer_slug_s]}") || args[:override_existing]
-              CacheThumbnailJob.perform_now(document.to_h)
+              CacheThumbnailJob.perform_later(document.to_h)
             end
           rescue Blacklight::Exceptions::RecordNotFound
             next
@@ -60,7 +60,7 @@ namespace :pulmap do
           puts "#{document[:layer_slug_s]} (#{doc_counter}/#{num_found})"
           begin
             if !Rails.cache.exist?("thumbnails/#{document[:layer_slug_s]}") || args[:override_existing]
-              CacheThumbnailJob.perform_now(document.to_h)
+              CacheThumbnailJob.perform_later(document.to_h)
             end
           rescue Blacklight::Exceptions::RecordNotFound
             next

--- a/spec/lib/sidekiq_chart_spec.rb
+++ b/spec/lib/sidekiq_chart_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe SidekiqChart do
+  let(:stats) { instance_double(Sidekiq::Stats, enqueued: 100, processed: 50, failed: 3) }
+  let(:retry_set) { instance_double(Sidekiq::RetrySet, size: 2) }
+  let(:dead_set) { instance_double(Sidekiq::DeadSet, size: 1) }
+  let(:workers) { instance_double(Sidekiq::Workers, size: 5) }
+
+  before do
+    allow(Sidekiq::Stats).to receive(:new).and_return(stats)
+    allow(Sidekiq::RetrySet).to receive(:new).and_return(retry_set)
+    allow(Sidekiq::DeadSet).to receive(:new).and_return(dead_set)
+    allow(Sidekiq::Workers).to receive(:new).and_return(workers)
+  end
+
+  describe "#render" do
+    subject { described_class.new.render }
+
+    it { is_expected.to include("Busy      5") }
+    it { is_expected.to include("Enqueued    100") }
+    it { is_expected.to include("Processed     50") }
+    it { is_expected.to include("Failed      3") }
+    it { is_expected.to include("Retries      2") }
+    it { is_expected.to include("Dead      1") }
+  end
+end


### PR DESCRIPTION
- Sets up Sidekiq to process background jobs
- Adds rake tasks to clear jobs and stats
- Adds adorable command line rake task for monitoring Sidekiq job progress without mounting the web UI.

![screenshot 2017-12-01 15 49 46](https://user-images.githubusercontent.com/784196/33505022-8015d746-d6af-11e7-82a7-d4d9b8b2805c.png)
