### PR TITLE
Remove honeybadger require from Capfile

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -33,5 +33,3 @@ require 'capistrano/passenger'
 
 # Load custom tasks from `lib/capistrano/tasks` if you have any defined
 Dir.glob('lib/capistrano/tasks/*.rake').each { |r| import r }
-
-require 'capistrano/honeybadger'


### PR DESCRIPTION
Removes unnecessary honeybadger require in Capfile that prevents automated deploys.