### PR TITLE
Don't use proxy wms url when generating thumbnails

### DIFF
--- a/app/services/thumbnail_service/wms.rb
+++ b/app/services/thumbnail_service/wms.rb
@@ -9,7 +9,11 @@ class ThumbnailService
     # @param [Integer] thumbnail size
     # @return [String] wms thumbnail url
     def self.thumbnail_url(document, size)
-      "#{document.viewer_endpoint}/reflect?" \
+      # Swap proxy url with princeton geoserver url.
+      # Thumbnail requests send geoserver auth.
+      endpoint = document.viewer_endpoint.gsub(Settings.PROXY_GEOSERVER_URL,
+                                               Settings.PRINCETON_GEOSERVER_URL)
+      "#{endpoint}/reflect?" \
         '&FORMAT=image%2Fpng' \
         '&TRANSPARENT=TRUE' \
         "&LAYERS=#{document['layer_id_s']}" \

--- a/spec/controllers/thumbnails_controller_spec.rb
+++ b/spec/controllers/thumbnails_controller_spec.rb
@@ -82,9 +82,10 @@ RSpec.describe ThumbnailsController, type: :controller do
         get :index, params: { id: "princeton-m613n013z" }
         expect(connection).to have_received(:authorization).with(:Basic, "realuser:realpass")
       end
-      it "caches a thumbnail via geoserver proxy" do
+      it "caches a thumbnail via geoserver server and not the geoserver proxy" do
         get :index, params: { id: "princeton-m613n013z" }
-        expect(Faraday).to have_received(:new).with(url: /restricted:pks65mg55/)
+        expect(Faraday).to have_received(:new)
+          .with(url: /geoserver.princeton.edu.*restricted:pks65mg55/)
       end
     end
 


### PR DESCRIPTION
Enables generation of restricted Princeton WMS thumbnails. Closes #476.