### PR TITLE
Ensuring that the sort and per-page controls are left-anchored when viewed on smaller screen sizes

### DIFF
--- a/app/assets/stylesheets/components/header.scss
+++ b/app/assets/stylesheets/components/header.scss
@@ -212,7 +212,7 @@
 
 .logo__pul a {
   display: inline-block;
-  
+
   &.pul-logo {
     @include vertical-align;
   }
@@ -518,4 +518,11 @@
 
 .navbar-fixed-top {
   z-index: 1000;
+}
+
+.search-widgets {
+  float: right;
+  @media (max-width: 1508px) {
+    float: none;
+  }
 }

--- a/app/views/catalog/_sort_and_per_page.html.erb
+++ b/app/views/catalog/_sort_and_per_page.html.erb
@@ -1,6 +1,6 @@
 <%- if !@response.empty? %>
 <div id="sortAndPerPage" class="clearfix">
   <%= render :partial => "paginate_compact", :object => @response if show_pagination? %>
-  <%= render_results_collection_tools wrapping_class: "search-widgets pull-right" %>
+  <%= render_results_collection_tools wrapping_class: "search-widgets" %>
 </div>
 <%- end %>


### PR DESCRIPTION
Resolves #484 