### PR TITLE
Update workspaces allowed in geoserver reverse proxy

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,6 +54,7 @@ Rails.application.routes.draw do
   resources :suggest, only: :index, defaults: { format: 'json' }
 
   authenticate :user do
-    match 'geoserver/restricted/*path' => 'geoserver#index', via: [:get]
+    match 'geoserver/restricted-figgy/*path' => 'geoserver#index', via: [:get]
+    match 'geoserver/restricted-figgy-staging/*path' => 'geoserver#index', via: [:get]
   end
 end

--- a/spec/features/geoserver_spec.rb
+++ b/spec/features/geoserver_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe 'geoserver proxy' do
   it 'proxy requires authentication' do
-    visit '/geoserver/restricted/wms'
+    visit '/geoserver/restricted-figgy/wms'
     expect(page).to have_current_path(user_session_path)
   end
 end


### PR DESCRIPTION
Enables previewing of new figgy vector layers.

Closes #511 