### PR TITLE
Update deprecated methods

### DIFF
--- a/app/helpers/advanced_helper.rb
+++ b/app/helpers/advanced_helper.rb
@@ -154,7 +154,7 @@ module BlacklightAdvancedSearch
     def guided_search(my_params = params)
       constraints = []
       if my_params[:q1].present?
-        label = search_field_def_for_key(my_params[:f1])[:label]
+        label = blacklight_config.search_fields[my_params[:f1]][:label]
         query = my_params[:q1]
         constraints << render_constraint_element(
           label, query,
@@ -162,7 +162,7 @@ module BlacklightAdvancedSearch
         )
       end
       if my_params[:q2].present?
-        label = search_field_def_for_key(my_params[:f2])[:label]
+        label = blacklight_config.search_fields[my_params[:f2]][:label]
         query = my_params[:q2]
         query = 'NOT ' + my_params[:q2] if my_params[:op2] == 'NOT'
         constraints << render_constraint_element(
@@ -171,7 +171,7 @@ module BlacklightAdvancedSearch
         )
       end
       if my_params[:q3].present?
-        label = search_field_def_for_key(my_params[:f3])[:label]
+        label = blacklight_config.search_fields[my_params[:f3]][:label]
         query = my_params[:q3]
         query = 'NOT ' + my_params[:q3] if my_params[:op3] == 'NOT'
         constraints << render_constraint_element(

--- a/app/views/advanced/_advanced_search_submit_btns.html.erb
+++ b/app/views/advanced/_advanced_search_submit_btns.html.erb
@@ -1,7 +1,7 @@
 <div class="sort-buttons pull-left">
   <%= label_tag(:sort, t('blacklight_advanced_search.form.sort_label'), :class => "control-label") %>
 
-  <%= select_tag(:sort, options_for_select(sort_fields, h(params[:sort])), :class => "sort-select") %>
+  <%= select_tag(:sort, options_for_select(blacklight_config.sort_fields, h(params[:sort])), :class => "sort-select") %>
   <%= hidden_field_tag(:search_field, blacklight_config.advanced_search[:url_key]) %>
 </div>
 


### PR DESCRIPTION
- Replaces deprecated `search_field_def_for_key` and `sort_fields` methods.
- There is still a deprecation warning on `search_field_def_for_key` because it's used in the blacklight_advanced_search gem. This will remain until it's updated. This might have to wait until the blacklight 7 changeover.

Closes #507