### PR TITLE
Disable IIIF-only download for Princeton scanned maps

### DIFF
--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -21,4 +21,11 @@ class SolrDocument
   # and Blacklight::Document::SemanticFields#to_semantic_values
   # Recommendation: Use field names from Dublin Core
   use_extension(Blacklight::Document::DublinCore)
+
+  # Override to disable iiif downloads for Princeton scanned maps because the user
+  # can download the images using the Universal Viewer.
+  def iiif_download
+    return super unless same_institution?
+    false
+  end
 end

--- a/app/views/catalog/_downloads.html.erb
+++ b/app/views/catalog/_downloads.html.erb
@@ -9,7 +9,7 @@
       <div class='panel-body'>
         <%= link_to t('geoblacklight.tools.login_to_view'), user_cas_omniauth_authorize_path %>
       </div>
-  <% else %>
+  <% elsif document.restricted? %>
     <%= link_to('Request offline access', '/contact-us') %>
   <% end %>
 <% elsif document_downloadable? %>

--- a/spec/features/show_downloads_spec.rb
+++ b/spec/features/show_downloads_spec.rb
@@ -20,4 +20,9 @@ describe 'Show page downloads' do
     visit solr_document_path('stanford-cz128vq0535')
     expect(page).to have_link 'Download Shapefile'
   end
+
+  it 'does not render the download link for public Princeton scanned maps without tiff download' do
+    visit solr_document_path('princeton-1r66j405w')
+    expect(page).not_to have_css '#downloadsLink'
+  end
 end


### PR DESCRIPTION
- Removes the sidebar download link for scanned map records without downloadable tiff images, like Sanborn MapSets. 
- Users can download JPEGs using the UniversalViewer for these items. IIIF-only download is redundant, and for MapSets, not useful. 

Closes #276 

![screenshot 2018-05-09 14 56 16](https://user-images.githubusercontent.com/784196/39837066-f4afcd74-539a-11e8-9f9f-c3fd6cf26af7.png)
