### PR TITLE
Revert to default document numbering strategy

### DIFF
--- a/app/views/catalog/_index_split_default.html.erb
+++ b/app/views/catalog/_index_split_default.html.erb
@@ -3,7 +3,7 @@
 <% counter = document_counter_with_offset(document_counter) %>
 <h3 class="index_title col-xs-12 text-span">
   <span class="document-counter">
-    <%= t('blacklight.search.documents.counter', :counter => document_counter + 1) if counter %>
+    <%= t('blacklight.search.documents.counter', :counter => counter) if counter %>
   </span>
   <%= link_to_document document, document_show_link_field(document), counter: counter, title: document[blacklight_config.index.title_field] %>
 </h3>


### PR DESCRIPTION
Does not reset the document numbers as users page through search results.

Closes #460 

