### PR TITLE
Allows downloading generated content from restricted Princeton vector layers

### DIFF
--- a/config/initializers/download.rb
+++ b/config/initializers/download.rb
@@ -1,0 +1,39 @@
+module Geoblacklight
+  class Download
+  ##
+  # Monkey patch of Geoblacklight::Download that injects geoserver auth
+  # credentials for restriced princeton wms layers. Delete this as soon as 
+  # geoblacklight downloads become configurable or multiple direct downloads
+  # are integrated into the document schema.
+  def initiate_download
+    auth = geoserver_credentials
+    conn = Faraday.new(url: url)
+    conn.authorization :Basic, auth if auth
+    conn.get do |request|
+      request.params = @options[:request_params]
+      request.options.timeout = timeout
+      request.options.open_timeout = timeout
+    end
+  rescue Faraday::Error::ConnectionFailed
+    raise Geoblacklight::Exceptions::ExternalDownloadFailed,
+          message: 'Download connection failed',
+          url: conn.url_prefix.to_s
+  rescue Faraday::Error::TimeoutError
+    raise Geoblacklight::Exceptions::ExternalDownloadFailed,
+          message: 'Download timed out',
+          url: conn.url_prefix.to_s
+  end
+
+  private
+
+    def geoserver_credentials
+      return unless restricted_wms_layer?
+      Settings.PROXY_GEOSERVER_AUTH.gsub('Basic ', '')
+    end
+
+    # Checks if the document is Princeton restriced access and is a wms layer.
+    def restricted_wms_layer?
+      @document.princeton_restricted? && @document.viewer_protocol == 'wms'
+    end
+  end
+end

--- a/spec/lib/download_spec.rb
+++ b/spec/lib/download_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+describe Geoblacklight::Download do
+  let(:connection) { instance_double('Faraday::Connection') }
+  let(:download) { Geoblacklight::ShapefileDownload.new(document, options) }
+  let(:options) do
+    {
+      type: 'shapefile',
+      extension: 'zip',
+      service_type: 'wms',
+      content_type: 'application/zip'
+    }
+  end
+  let(:references) do
+    { 'http://www.opengis.net/def/serviceType/ogc/wms' => 'http://www.example.com/wms' }.to_json
+  end
+  let(:request) { instance_double('Faraday::Request') }
+
+  before do
+    allow(Faraday).to receive(:new).and_return(connection)
+    allow(connection).to receive(:get).and_return(request)
+    allow(Settings).to receive(:PROXY_GEOSERVER_AUTH).and_return("realuser:realpass")
+    allow(connection).to receive(:authorization)
+  end
+
+  describe '#initiate_download' do
+    context 'with a public record with wms endpoint' do
+      let(:document) do
+        SolrDocument.new(layer_slug_s: 'test',
+                         dct_references_s: references)
+      end
+
+      it 'requests download from server without using basic authorization' do
+        download.initiate_download
+        expect(Faraday).to have_received(:new).with(url: 'http://www.example.com/wms')
+        expect(connection).not_to have_received(:authorization).with(:Basic, "realuser:realpass")
+      end
+    end
+
+    context 'with a non-public princeton record with wms endpoint' do
+      let(:document) do
+        SolrDocument.new(layer_slug_s: 'test',
+                         dct_provenance_s: 'Princeton',
+                         dc_rights_s: 'Restricted',
+                         dct_references_s: references)
+      end
+
+      it 'request download from server using basic authorization' do
+        download.initiate_download
+        expect(Faraday).to have_received(:new).with(url: 'http://www.example.com/wms')
+        expect(connection).to have_received(:authorization).with(:Basic, "realuser:realpass")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Monkey patches `Geoblacklight::Download` to inject auth credentials for downloading GeoServer generated content on restricted Princeton vector layers.

Closes #520 