### PR TITLE
Redirect to 404 when document is not downloadable

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,12 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
 
+  def not_found
+    raise ActionController::RoutingError, 'Not Found'
+  rescue ActionController::RoutingError
+    render_404
+  end
+
   private
 
   def after_sign_in_path_for(_resource)
@@ -14,5 +20,9 @@ class ApplicationController < ActionController::Base
     else
       root_path
     end
+  end
+
+  def render_404
+    render file: Rails.root.join("public", "404"), status: :not_found
   end
 end

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -275,5 +275,6 @@ class CatalogController < ApplicationController
 
   def downloads
     @response, @document = fetch params[:id]
+    not_found unless @document.downloadable? && @document.same_institution?
   end
 end

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -10,10 +10,26 @@ describe CatalogController, type: :controller do
     end
   end
   describe '#downloads' do
-    it 'download page renders' do
-      get :downloads, params: { id: 'princeton-kk91fn37z' }
-      expect(response).to have_http_status(200)
-      expect(assigns(:document)).not_to be_nil
+    context 'with a downloadable Princeton item' do
+      it 'renders dowload page' do
+        get :downloads, params: { id: 'princeton-m613n013z' }
+        expect(response).to have_http_status(200)
+        expect(assigns(:document)).not_to be_nil
+      end
+    end
+
+    context 'with a downloadable non-Princeton item' do
+      it 'redirects with a 404' do
+        get :downloads, params: { id: 'nyu_2451_34548' }
+        expect(response).to have_http_status(404)
+      end
+    end
+
+    context 'with a non-downloadable Princeton item' do
+      it 'redirects with a 404' do
+        get :downloads, params: { id: 'princeton-02870w62c' }
+        expect(response).to have_http_status(404)
+      end
     end
   end
 end


### PR DESCRIPTION
Redirect to 404 page when attempting to access downloads route on non-downloadable or non-Princeton documents.
 
Closes #556 