### PR TITLE
Updates bootstrap-sass to release 3.4.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,7 @@ end
 
 gem 'blacklight_advanced_search'
 gem 'blacklight_range_limit'
+gem 'bootstrap-sass', '~> 3.4'
 gem 'bourbon', '4.3.4'
 gem 'capistrano', '~> 3.7.1'
 gem 'capistrano-bundler'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,9 +87,9 @@ GEM
       blacklight (>= 6.0.2)
       jquery-rails
       rails (>= 3.0)
-    bootstrap-sass (3.3.7)
+    bootstrap-sass (3.4.1)
       autoprefixer-rails (>= 5.2.1)
-      sass (>= 3.3.4)
+      sassc (>= 2.0.0)
     bourbon (4.3.4)
       sass (~> 3.4)
       thor (~> 0.19)
@@ -424,6 +424,9 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
+    sassc (2.0.1)
+      ffi (~> 1.9)
+      rake
     serverengine (2.0.7)
       sigdump (~> 0.2.2)
     sidekiq (5.2.2)
@@ -506,6 +509,7 @@ DEPENDENCIES
   autoprefixer-rails
   blacklight_advanced_search
   blacklight_range_limit
+  bootstrap-sass (~> 3.4)
   bourbon (= 4.3.4)
   byebug
   capistrano (~> 3.7.1)
@@ -561,4 +565,4 @@ DEPENDENCIES
   webpacker (~> 3.2)
 
 BUNDLED WITH
-   1.16.6
+   1.17.2


### PR DESCRIPTION
Ensures that the bootstrap-sass release is pinned to the 3.4.1 release.