### PR TITLE
Update gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,14 +33,14 @@ group :development, :test do
 end
 
 group :development do
-  gem 'web-console'
+  gem 'web-console', '~> 3.7.0'
 end
 
 gem 'blacklight_advanced_search'
 gem 'blacklight_range_limit'
-gem 'bootstrap-sass', '~> 3.4'
+gem 'bootstrap-sass'
 gem 'bourbon', '4.3.4'
-gem 'capistrano', '~> 3.7.1'
+gem 'capistrano'
 gem 'capistrano-bundler'
 gem 'capistrano-passenger'
 gem 'capistrano-rails'
@@ -61,5 +61,5 @@ gem 'simple_form'
 gem 'sitemap_generator', '~> 6.0'
 gem 'sneakers'
 gem 'solr_wrapper'
-gem 'twitter-typeahead-rails', '0.11.1.pre.corejavascript'
+gem 'twitter-typeahead-rails'
 gem 'webpacker'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -522,10 +522,10 @@ DEPENDENCIES
   bixby
   blacklight_advanced_search
   blacklight_range_limit
-  bootstrap-sass (~> 3.4)
+  bootstrap-sass
   bourbon (= 4.3.4)
   byebug
-  capistrano (~> 3.7.1)
+  capistrano
   capistrano-bundler
   capistrano-passenger
   capistrano-rails
@@ -569,9 +569,9 @@ DEPENDENCIES
   spring
   sqlite3
   turbolinks
-  twitter-typeahead-rails (= 0.11.1.pre.corejavascript)
+  twitter-typeahead-rails
   uglifier
-  web-console
+  web-console (~> 3.7.0)
   webdrivers
   webpacker
 


### PR DESCRIPTION
blacklight_advanced_search is blocking the GBL 2.1.2 update.
The latest version: `gem 'blacklight_advanced_search', '~> 6.4', '>= 6.4.1', supports: gem blacklight' >= 6.0.1, ~> 6.0`