### PR TITLE
update navbar in mobile view for index-layout; show_layout & navbar; deprecation

### DIFF
--- a/app/assets/stylesheets/components/header.scss
+++ b/app/assets/stylesheets/components/header.scss
@@ -1,4 +1,4 @@
-
+/* .header__secondary is used in orangelight */
 
 @include media-breakpoint-only(sm) {
   .header__secondary .container {
@@ -131,8 +131,7 @@
   padding: 0;
   list-style-type: none;
   text-align: center;
-  vertical-align: bottom;
-  float: right;
+
 
   @include media-breakpoint-only(sm) {
     @include vertical-align;

--- a/app/assets/stylesheets/components/search.scss
+++ b/app/assets/stylesheets/components/search.scss
@@ -27,7 +27,7 @@
   }
 }
 
-header .navbar-form .input-group .input-group-btn {
+header .navbar-form .input-group .input-group-append {
   width: 40px;
 }
 
@@ -163,7 +163,7 @@ header .input-group-addon {
   li {
     display: inline-block;
 
-    @media (min-width: 500px) {
+    @include media-breakpoint-up(xs) {
       padding-right: 1em;
     }
   }

--- a/app/views/catalog/_previous_next_doc.html.erb
+++ b/app/views/catalog/_previous_next_doc.html.erb
@@ -1,9 +1,9 @@
 <% #Using the Bootstrap Pagination class  -%>
 <% #DEPRECATED - using id="previousNextDocument" as a selector is deprecated and will be removed in Blacklight 6.0 %>
-<div id='previousNextDocument' class='pagination-search-widgets'>
+<div class='pagination-search-widgets'>
 <% if current_search_session %>
   <%=link_to t('blacklight.search.start_over').html_safe, start_over_path(current_search_session.try(:query_params) || {}), id: 'startOverLink', class: 'btn btn-primary button--start-over' %>
-  <%= link_back_to_catalog class: 'btn btn-default button--back-to-search' %>
+  <%= link_back_to_catalog class: 'btn btn-outline-secondary button--back-to-search' %>
 <% end %>
   <% if @previous_document || @next_document %>
     <div class="page_links">

--- a/app/views/catalog/index.html.erb
+++ b/app/views/catalog/index.html.erb
@@ -1,4 +1,4 @@
-<div id="content" class="content col col-sm-12 col-md-4">
+<div id="content" class="content col-12 col-sm-12 col-md-4">
   <%= render 'search_header' %>
   <div id="inner" aria-live="polite">
     <%= render 'search_results' %>

--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -1,39 +1,39 @@
-<div class="col-md-12 show-document">
-  <%= render 'previous_next_doc' %>
-</div>
+<div class="row">
+  <div class="col-6 show-document">
+    <%= render 'previous_next_doc' %>
+  </div>
 
-<div class="col-md-12">
-  <%= render partial: 'show_header_default', locals: { document: @document } %>
-</div>
+  <div class="col-12">
+    <%= render partial: 'show_header_default', locals: { document: @document } %>
+  </div>
 
-<div id="item-record" class="col-lg-9 col-md-8 show-document">
+  <div id="item-record" class="col-12 col-md-8 col-lg-9 show-document">
 
-<% @page_title = t('blacklight.search.show.title', :document_title => document_show_html_title, :application_name => application_name).html_safe -%>
-<% content_for(:head) { render_link_rel_alternates } -%>
-<%# this should be in a partial -%>
+    <% @page_title = t('blacklight.search.show.title', :document_title => document_show_html_title, :application_name => application_name).html_safe -%>
+    <% content_for(:head) { render_link_rel_alternates } -%>
+    <%# this should be in a partial -%>
 
-<div id="document" class="document <%= render_document_class %>" itemscope  itemtype="<%= @document.itemtype %>">
-  <div id="doc_<%= @document.id.to_s.parameterize %>">
+    <div id="document" class="document <%= render_document_class %>" itemscope  itemtype="<%= @document.itemtype %>">
+      <div id="doc_<%= @document.id.to_s.parameterize %>">
 
-    <% # bookmark/folder functions -%>
-    <%= render_document_partials @document, blacklight_config.view_config(:show).partials %>
+        <% # bookmark/folder functions -%>
+        <%= render_document_partials @document, blacklight_config.view_config(:show).partials %>
+
+      </div>
+    </div>
+
+    <% if @document.respond_to?(:export_as_openurl_ctx_kev) %>
+      <!--
+           // COinS, for Zotero among others.
+           // This document_partial_name(@document) business is not quite right,
+           // but has been there for a while.
+      -->
+      <span class="Z3988" title="<%= @document.export_as_openurl_ctx_kev(document_partial_name(@document)) %>"></span>
+    <% end %>
 
   </div>
-</div>
 
-
-
-  <% if @document.respond_to?(:export_as_openurl_ctx_kev) %>
-    <!--
-         // COinS, for Zotero among others.
-         // This document_partial_name(@document) business is not quite right,
-         // but has been there for a while.
-    -->
-    <span class="Z3988" title="<%= @document.export_as_openurl_ctx_kev(document_partial_name(@document)) %>"></span>
-  <% end %>
-
-</div>
-
-<div id="tools-sidebar" class="col-lg-3 col-md-4 tools-sidebar">
-   <%= render_document_sidebar_partial %>
+  <div id="tools-sidebar" class="col-12 col-md-4 col-lg-3 tools-sidebar">
+     <%= render_document_sidebar_partial %>
+  </div>
 </div>

--- a/app/views/shared/_pul_branding.html.erb
+++ b/app/views/shared/_pul_branding.html.erb
@@ -2,7 +2,7 @@
   <div class="<% unless index_layout? %>container<% end %> <%= layout_type %>-container ">
     <nav class="navbar <%= navbar_type %> navbar-dark bg-dark">
       
-        <div class="logo__pul col col-sm-5 col-md-4">
+        <div class="logo__pul col-12 col-sm-5 col-md-4">
           <a href="https://library.princeton.edu" title="Princeton University Library" class="pul-logo">
            <%= image_tag("pul-logo-new.svg") %>
           </a>
@@ -11,7 +11,7 @@
           <% end %>
         </div>
         <% if index_layout? %>
-          <div class="col col-sm-5 col-md-4">
+          <div class="col-12 col-sm-5 col-md-4">
             <%= render :partial=>'catalog/search_form_index' %>
           </div>
 
@@ -23,7 +23,7 @@
             </ul>
           </div>
         <% end %>
-        <div class="menu--level-1 d-none d-sm-block col-sm-2 col-md-3">
+        <div class="menu--level-1 d-none d-sm-block col-sm-2 col-md-3 ml-auto justify-content-sm-end">
           <ul>
             <li><a href="/contact-us">Contact Us</a></li>
             <%= render :partial=>'/account' %>


### PR DESCRIPTION
closes #675

1.update navbar in mobile view for index-layout
2.update show page layout
3.removes #DEPRECATED - using id="previousNextDocument"
4.updates button for back to search
5.updates some of the media breakpoints