### PR TITLE
Fixes Back to search button in the wide screen while displaying only th…

### DIFF
--- a/app/views/catalog/_previous_next_doc.html.erb
+++ b/app/views/catalog/_previous_next_doc.html.erb
@@ -3,7 +3,7 @@
 <div class='pagination-search-widgets'>
 <% if current_search_session %>
   <%=link_to t('blacklight.search.start_over').html_safe, start_over_path(current_search_session.try(:query_params) || {}), id: 'startOverLink', class: 'btn btn-primary button--start-over' %>
-  <%= link_back_to_catalog class: 'btn btn-outline-secondary button--back-to-search' %>
+  <%= link_back_to_catalog class: 'btn btn-outline-primary button--back-to-search' %>
 <% end %>
   <% if @previous_document || @next_document %>
     <div class="page_links">

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -13,7 +13,7 @@ en:
       title: 'Digital Maps and Geospatial Data | Princeton University'
     header_links:
       account_page: 'Your Account'
-    back_to_search: '<span class="icon-moveback"></span> <span class="d-none d-md-block">Back to search</span>'
+    back_to_search: '<span class="icon-moveback"></span> <span class="d-none d-md-inline-block">Back to search</span>'
     feedback:
       success: 'Your comments have been submitted'
       error: 'Please fill in the required form values.'


### PR DESCRIPTION
Fixes the 'Back to search' button in the show page to display the text and arrow in one block. 
The arrow will display with no text in `xs` `sm` screens
Uses the bs4 btn outline primary btn to preserve the blue color when hover over the btn.

closes #677 