### PR TITLE
Update Solr config and use OVERLAP_RATIO_BOOST for spatial relevancy

### DIFF
--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -16,15 +16,4 @@ class SearchBuilder < Blacklight::SearchBuilder
     solr_params[:fq] ||= []
     solr_params[:fq] << '-suppressed_b: true'
   end
-
-  # Override to use IsWithin instead of Intesects
-  def add_spatial_params(solr_params)
-    if blacklight_params[:bbox]
-      solr_params[:fq] ||= []
-      solr_params[:fq] << "#{Settings.FIELDS.GEOMETRY}:\"IsWithin(#{envelope_bounds})\""
-    end
-    solr_params
-  rescue Geoblacklight::Exceptions::WrongBoundingBoxFormat
-    solr_params
-  end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,7 +1,10 @@
 # Configurable Logo Used for CartoDB export
 APPLICATION_LOGO_URL: 'http://geoblacklight.org/images/geoblacklight-logo.png'
 
-BBOX_WITHIN_BOOST: '300'
+BBOX_WITHIN_BOOST: '10'
+
+# The bf boost value for overlap ratio
+OVERLAP_RATIO_BOOST: '10'
 
 # Carto OneClick Service https://cartodb.com/open-in-cartodb/
 CARTO_ONECLICK_LINK: 'http://oneclick.cartodb.com/'

--- a/solr/conf/schema.xml
+++ b/solr/conf/schema.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<schema name="geoblacklight-schema" version="1.6">
+<schema name="geoblacklight-schema" version="1.7">
   <uniqueKey>layer_slug_s</uniqueKey>
   <fields>
     <field name="_version_" type="long"   stored="true" indexed="true"/>
@@ -64,6 +64,7 @@
     <dynamicField name="*_pt"   type="location"     stored="true" indexed="true"/>
     <dynamicField name="*_bbox" type="location_rpt" stored="true" indexed="true"/><!-- deprecated -->
     <dynamicField name="*_geom" type="location_rpt" stored="true" indexed="true"/>
+    <dynamicField name="*_bboxtype" type="bbox" stored="true" indexed="true"/>
   </fields>
 
   <types>
@@ -144,7 +145,10 @@
 
     <fieldType name="location_rpt" class="solr.SpatialRecursivePrefixTreeFieldType"
                geo="true" distErrPct="0.025" maxDistErr="0.001" distanceUnits="kilometers"/>
-
+    <!-- Adding field type for bboxField that enables, among other things, overlap ratio calculations -->
+    <fieldType name="bbox" class="solr.BBoxField"
+           geo="true" distanceUnits="kilometers" numberType="pdouble" />
+    <fieldType name="pdouble" class="solr.DoublePointField" docValues="true"/>
   </types>
 
   <!-- for scoring formula -->
@@ -187,4 +191,7 @@
   <copyField source="dct_provenance_s" dest="suggest"/>
   <copyField source="dc_subject_sm" dest="suggest"/>
   <copyField source="dct_spatial_sm" dest="suggest"/>
+
+  <!-- for bbox value -->
+  <copyField source="solr_geom" dest="solr_bboxtype"/>
 </schema>

--- a/solr/conf/solrconfig.xml
+++ b/solr/conf/solrconfig.xml
@@ -27,7 +27,7 @@
        that you fully re-index after changing this setting as it can
        affect both how text is indexed and queried.
   -->
-  <luceneMatchVersion>6.2.1</luceneMatchVersion>
+  <luceneMatchVersion>7.1</luceneMatchVersion>
 
   <lib dir="${solr.install.dir:../../../..}/contrib/analysis-extras/lib" />
   <lib dir="${solr.install.dir:../../../..}/contrib/analysis-extras/lucene-libs" />

--- a/spec/models/search_builder_spec.rb
+++ b/spec/models/search_builder_spec.rb
@@ -18,12 +18,6 @@ describe SearchBuilder do
       builder.with(params)
       expect(builder.add_spatial_params(solr_params)).to eq solr_params
     end
-
-    it 'returns a spatial search using IsWithin if bbox is given' do
-      params = { bbox: '-180 -80 120 80' }
-      builder.with(params)
-      expect(builder.add_spatial_params(solr_params)[:fq].to_s).to include('IsWithin')
-    end
   end
 
   describe '#add_featured_content' do


### PR DESCRIPTION
Improves spatial relevancy. We'll have to reindex all the documents in Pulmap, but it should improve the search experience.

Closes #354 