### PR TITLE
Updates the robots.txt file in order to block robots from crawling geospatial web service endpoints

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -60,6 +60,7 @@ Metrics/LineLength:
     - 'spec/lib/thumbnail_spec.rb'
     - 'spec/requests/advanced_request_spec.rb'
     - 'spec/services/robots_generator_service_spec.rb'
+    - 'spec/views/catalog/_web_services.erb_spec.rb'
 
 Metrics/MethodLength:
   Max: 14

--- a/app/services/thumbnail_service.rb
+++ b/app/services/thumbnail_service.rb
@@ -70,6 +70,8 @@ class ThumbnailService
       return placeholder_image
     rescue Faraday::Error::TimeoutError
       return placeholder_image
+    rescue Faraday::SSLError
+      return placeholder_image
     end
 
     # Returns the thumbnail url.

--- a/app/views/catalog/_web_services.html.erb
+++ b/app/views/catalog/_web_services.html.erb
@@ -1,0 +1,10 @@
+<% document ||= @documents.first %>
+
+<% if !document.nil? %>
+  <% document.references.refs.each do |reference| %>
+    <% if Settings.WEBSERVICES_SHOWN.include? reference.type.to_s %>
+      <%= render_web_services(reference) %>
+      <hr>
+    <% end %>
+  <% end %>
+<% end %>

--- a/config/robots.yml
+++ b/config/robots.yml
@@ -6,6 +6,7 @@ defaults: &defaults
     - '/*?f*'
     - '/bookmarks'
     - '/catalog/*/'
+    - '/catalog/*/web_services'
     - '/catalog/email'
     - '/catalog/opensearch'
     - '/catalog/range_limit'

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,10 +1,11 @@
 User-agent: *
 Crawl-delay: 10
-Sitemap: https://pulsearch.princeton.edu/sitemap.xml.gz
+Sitemap: https://maps.princeton.edu/sitemap.xml.gz
 Disallow: /*?q=*
 Disallow: /*?f*
 Disallow: /bookmarks
 Disallow: /catalog/*/
+Disallow: /catalog/*/web_services
 Disallow: /catalog/email
 Disallow: /catalog/opensearch
 Disallow: /catalog/range_limit

--- a/spec/views/catalog/_web_services.erb_spec.rb
+++ b/spec/views/catalog/_web_services.erb_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+describe 'catalog/_web_services.html.erb', type: :view do
+  before do
+    assign(:documents, [document])
+    render
+  end
+
+  context 'when the resource links to web service resources' do
+    let(:wms_reference) { Geoblacklight::Reference.new(["http://www.opengis.net/def/serviceType/ogc/wms", "http://geoserver01.uit.tufts.edu/wms"]) }
+    let(:wfs_reference) { Geoblacklight::Reference.new(["http://www.opengis.net/def/serviceType/ogc/wfs", "http://geoserver01.uit.tufts.edu/wfs"]) }
+    let(:references) { instance_double(Geoblacklight::References, refs: [wms_reference, wfs_reference]) }
+    let(:document) { instance_double(SolrDocument, references: references, wxs_identifier: 'sde:GISPORTAL.GISOWNER01.CAMBRIDGEGRID100_04') }
+
+    it 'links to each reference' do
+      expect(rendered).to have_css '#wms_webservice[value="http://geoserver01.uit.tufts.edu/wms"]'
+      expect(rendered).to have_css '#wfs_webservice[value="http://geoserver01.uit.tufts.edu/wfs"]'
+    end
+  end
+
+  context 'when the document cannot be resolved' do
+    let(:document) { nil }
+
+    it 'does not iterate through the references' do
+      expect(rendered).not_to have_css '#wms_webservice[value="http://geoserver01.uit.tufts.edu/wms"]'
+      expect(rendered).not_to have_css '#wfs_webservice[value="http://geoserver01.uit.tufts.edu/wfs"]'
+    end
+  end
+end


### PR DESCRIPTION
Also ensures that cases are handled where reference templates are rendered for `nil` `SolrDocuments`.  Advances #781.