### PR TITLE
Reinitialize autocomplete to add limit value

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -32,7 +32,7 @@
 //= require modules/map
 //= require modules/thumbnail
 //= require modules/advanced_chosen
-
+//= require modules/autocomplete
 //= require Leaflet.fullscreen
 //= require Leaflet.ExtraMarkers
 

--- a/app/assets/javascripts/modules/autocomplete.js
+++ b/app/assets/javascripts/modules/autocomplete.js
@@ -1,0 +1,33 @@
+// Reinitializes autocomplete to add limit value. Fixes issue where
+// autocomplete results are hidden. Can remove when fixed upstream.
+
+$(document).ready(function() {
+  $('[data-autocomplete-enabled="true"]').each(function () {
+    var $el = $(this);
+
+    if ($el.hasClass('tt-hint')) {
+      return;
+    }
+
+    var suggestUrl = $el.data().autocompletePath;
+    var terms = new Bloodhound({
+      datumTokenizer: Bloodhound.tokenizers.obj.whitespace('value'),
+      queryTokenizer: Bloodhound.tokenizers.whitespace,
+      remote: {
+        url: suggestUrl + '?q=%QUERY',
+        wildcard: '%QUERY'
+      }
+    });
+    terms.initialize();
+    $el.typeahead({
+      hint: true,
+      highlight: true,
+      minLength: 2
+    }, {
+      name: 'terms',
+      limit: 10,
+      displayKey: 'term',
+      source: terms.ttAdapter()
+    });
+  });
+});


### PR DESCRIPTION
Closes #780 

Fixes autocomplete on production. Tested with tunneled connection to the production solr instance. I'm not sure why exactly this works, but I will push this upstream to Blacklight and see if others might have insight into it.