### PR TITLE
Ensuring that "vector" icons are overridden with "polygon"

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -74,6 +74,10 @@ module ApplicationHelper
   # rubocop:disable Rails/OutputSafety
   def placeholder_thumbnail_icon(name, document)
     icon_name = name ? name.to_s.parameterize : 'none'
+    # Cases where 'vector' is generated for the icon name
+    # This may actually be a problem with the data (please see https://github.com/pulibrary/pulmap/issues/844)
+    icon_name = 'polygon' if icon_name == 'vector'
+
     icon = Blacklight::Icon.new(icon_name)
     icon.svg.html_safe
     link_to icon.svg.html_safe, url_for_document(document), document_link_params(document, {})

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -63,4 +63,26 @@ describe ApplicationHelper, type: :helper do
       expect(default_layout?).to be true
     end
   end
+  describe '#placeholder_thumbnail_icon' do
+    context 'when the document generates an icon with the name "vector"' do
+      let(:document) { SolrDocument.new }
+      let(:output) { placeholder_thumbnail_icon('vector', document) }
+
+      # This is necessary given the helper methods
+      # These are only available within within the context of the ApplicationHelper
+      define_method :url_for_document do |_doc|
+        'http://localhost/catalog/test'
+      end
+      define_method :document_link_params do |_doc, _options|
+        {}
+      end
+
+      it 'generates the "polygon" icon' do
+        expect(output).to include '<a href="http://localhost/catalog/test">'
+        expect(output).to include '<svg'
+        expect(output).to include 'polygon'
+        expect(output).to include '</svg>'
+      end
+    end
+  end
 end


### PR DESCRIPTION
Resolves #844 and addresses https://faq.library.princeton.edu/admin/ticket?qid=5482023