### PR TITLE
Add a weekly whenever job to regenerate the sitemap

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -18,20 +18,9 @@ require 'capistrano/rails/migrations'
 # deploy/restart task for passenger
 require 'capistrano/passenger'
 
-# Include tasks from other gems included in your Gemfile
-#
-# For documentation on these, see for example:
-#
-#   https://github.com/capistrano/rvm
-#   https://github.com/capistrano/rbenv
-#   https://github.com/capistrano/chruby
-#   https://github.com/capistrano/bundler
-#   https://github.com/capistrano/rails
-#   https://github.com/capistrano/passenger
-#
-# require 'capistrano/rvm'
-# require 'capistrano/rbenv'
-# require 'capistrano/chruby'
+# Run whenever crontab update tasks
+# https://github.com/javan/whenever/blob/master/lib/whenever/capistrano/v3/tasks/whenever.rake#L39-L40
+require "whenever/capistrano"
 
 # Load custom tasks from `lib/capistrano/tasks` if you have any defined
 Dir.glob('lib/capistrano/tasks/*.rake').each { |r| import r }

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -81,13 +81,3 @@ task :robots_txt do
   end
 end
 after 'deploy:published', 'robots_txt'
-
-desc "Generate the crontab tasks using Whenever"
-task :whenever do
-  on roles(:index) do
-    within release_path do
-      execute("cd #{release_path} && bundle exec whenever --update-crontab #{fetch :application} --set environment=#{fetch :rails_env, fetch(:stage, 'production')} --user deploy")
-    end
-  end
-end
-before "deploy:assets:precompile", "whenever"

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -8,6 +8,11 @@ env :PATH, ENV['PATH']
 # It's helpful, but not entirely necessary to understand cron before proceeding.
 # http://en.wikipedia.org/wiki/Cron
 
+# Run a weekly rake task to regenerate the sitemap.
+every :wednesday, at: "11:00 PM", roles: [:app] do
+  rake "sitemap:refresh"
+end
+
 # Run a daily rake task to harvest new thumbnail images.
 # These could be from new records or from records
 # where there was a previous error during harvesting.


### PR DESCRIPTION
1. Adds sitemap rake task to whenever config
1. Replaces custom whenever task runner with built-in whenever capistrano tasks. This enables per-role cron jobs to run correctly.