### PR TITLE
Blacklight::Exceptions::RecordNotFound to redirect to 404 page and not raise an exception

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -9,6 +9,10 @@ class CatalogController < ApplicationController
     redirect_to '/', flash: { error: 'The start year must be before the end year.' }
   end
 
+  rescue_from Blacklight::Exceptions::RecordNotFound do
+    redirect_to '/404'
+  end
+
   configure_blacklight do |config|
     # Ensures that JSON representations of Solr Documents can be retrieved using
     # the path /catalog/:id/raw

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -10,7 +10,7 @@ class CatalogController < ApplicationController
   end
 
   rescue_from Blacklight::Exceptions::RecordNotFound do
-    render file: Rails.root.join('public', '404.html'), layout: false, status: :not_found
+    render file: Rails.root.join('public', '404.html'), status: :not_found
   end
 
   configure_blacklight do |config|

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -10,7 +10,7 @@ class CatalogController < ApplicationController
   end
 
   rescue_from Blacklight::Exceptions::RecordNotFound do
-    redirect_to '/404'
+    render file: Rails.root.join('public', '404.html'), layout: false, status: :not_found
   end
 
   configure_blacklight do |config|

--- a/spec/features/show_page_spec.rb
+++ b/spec/features/show_page_spec.rb
@@ -9,4 +9,12 @@ describe 'Show page' do
       expect(page).not_to have_content 'Login to view and download'
     end
   end
+
+  describe 'response to Blacklight::Exceptions::RecordNotFound exception' do
+    it 'redirects to the 404 page' do
+      visit solr_document_path 'princeton-kk91fn37znotfound'
+      expect(page).to have_content "The page you were looking for doesn't exist.\nYou may have mistyped the address or"
+      expect { page }.not_to raise_error
+    end
+  end
 end

--- a/spec/features/show_page_spec.rb
+++ b/spec/features/show_page_spec.rb
@@ -15,6 +15,7 @@ describe 'Show page' do
       visit solr_document_path 'princeton-kk91fn37znotfound'
       expect(page).to have_content "The page you were looking for doesn't exist.\nYou may have mistyped the address or"
       expect { page }.not_to raise_error
+      expect(page.status_code).to eq 404
     end
   end
 end


### PR DESCRIPTION
closes #880