### PR TITLE
Handles errors in link_back_to_catalog

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -85,4 +85,12 @@ module ApplicationHelper
     link_to Blacklight::Icon.new('mixed').svg.html_safe, url_for_document(document), document_link_params(document, {})
   end
   # rubocop:enable Rails/OutputSafety
+
+  # Shadows Blacklight's link_back_to_catalog but handles gracefully if there is an error generating the URL
+  # with the parameters in the request.
+  def link_back_to_catalog_safe(opts = { label: nil })
+    link_back_to_catalog(opts)
+  rescue ActionController::UrlGenerationError
+    "/"
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -86,11 +86,13 @@ module ApplicationHelper
   end
   # rubocop:enable Rails/OutputSafety
 
-  # Shadows Blacklight's link_back_to_catalog but handles gracefully if there is an error generating the URL
-  # with the parameters in the request.
   def link_back_to_catalog_safe(opts = { label: nil })
     link_back_to_catalog(opts)
   rescue ActionController::UrlGenerationError
-    "/"
+    # This exception is triggered if the user's session has information that results in an
+    # invalid back to catalog link. In that case, rather than blowing up on the user, we
+    # render a valid link. This link does not preserve the user's previous setings and that is
+    # OK because very likely their session is corrupted.
+    link_to "Back to search", root_url
   end
 end

--- a/app/views/catalog/_previous_next_doc.html.erb
+++ b/app/views/catalog/_previous_next_doc.html.erb
@@ -2,7 +2,7 @@
 <div class='pagination-search-widgets'>
   <%=link_to t('blacklight.search.start_over').html_safe, start_over_path(current_search_session.try(:query_params) || {}), id: 'startOverLink', class: 'btn btn-primary button--start-over' %>
   <% if current_search_session %>
-    <%= link_back_to_catalog class: 'btn btn-outline-primary button--back-to-search', label:  t('blacklight.back_to_search').html_safe %>
+    <%= link_back_to_catalog_safe class: 'btn btn-outline-primary button--back-to-search', label:  t('blacklight.back_to_search').html_safe %>
   <% end %>
 
   <% if @search_context && (@search_context[:prev] || @search_context[:next]) %>


### PR DESCRIPTION
Handles gracefully when a link back to the catalog cannot be generated with the request's parameters.

This is to address the issue reported in Honeybadger (https://app.honeybadger.io/projects/54400/faults/53308246) when trying to generate the link back to the catalog with bad parameters in the request.  

Ideally this should be fixed in Blacklight, but for now, this will fix the issue here.

Fixes #826 

See also https://github.com/pulibrary/orangelight/pull/2496