### PR TITLE
Update Harvard harvesting url

### DIFF
--- a/config/initializers/geocombine.rb
+++ b/config/initializers/geocombine.rb
@@ -24,7 +24,7 @@ GeoCombine::GeoBlacklightHarvester.configure do
       }
     },
     HARVARD: {
-      host: 'https://earthworks.stanford.edu/',
+      host: 'https://hgl.harvard.edu/',
       params: {
         q: '*',
         f: {


### PR DESCRIPTION
Updates Url for harvesting Harvard metadata. New GeoBlacklight site.