### PR TITLE
Remove unused ActiveSupport::MessageVerifier::InvalidSignature rescue

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,8 +9,7 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
   RESCUE_WITH_404 = [
-    Blacklight::Exceptions::RecordNotFound,
-    ActiveSupport::MessageVerifier::InvalidSignature
+    Blacklight::Exceptions::RecordNotFound
   ].freeze
 
   rescue_from(*RESCUE_WITH_404) do

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -10,16 +10,4 @@ describe CatalogController, type: :controller do
       it { is_expected.to be false }
     end
   end
-
-  describe 'ActiveStorage error handling' do
-    before do
-      allow(controller).to receive(:index).and_raise ActiveSupport::MessageVerifier::InvalidSignature
-    end
-
-    it 'does not raise error' do
-      get :index
-      expect { response }.not_to raise_error
-      expect(response).to have_http_status(404)
-    end
-  end
 end


### PR DESCRIPTION
Closes #949 