### PR TITLE
Run rubocop directly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,7 +112,7 @@ jobs:
       - run: gem install bundler -v '~> 2.0'
       # Bundle install dependencies
       - run: bundle install --path vendor/bundle
-      - run: bundle exec rake rubocop
+      - run: bundle exec rubocop
 workflows:
   version: 2
   build_accept_deploy:


### PR DESCRIPTION
Removes (unnecessary?) rake invocation of rubocop. Might fix flaky rubocop CI runs. Rake was one of the gems that was recently upgraded.

Closes #1118