### PR TITLE
Add env and service to datadog tracing

### DIFF
--- a/config/initializers/datadog.rb
+++ b/config/initializers/datadog.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 Datadog.configure do |c|
   c.tracer(enabled: false) unless Rails.env.production?
+  c.env = Rails.env.to_s
+  c.service = "pulmap"
+
   # Rails
   c.use :rails
 


### PR DESCRIPTION
this keeps it from having env:none in apm.

advances pulibrary/ops-catchall#37
